### PR TITLE
Add wafflestudio-clsuter admin to mapUsers of aws-auth configmap as system:masters

### DIFF
--- a/misc/kube-system/configmap/aws-auth.yaml
+++ b/misc/kube-system/configmap/aws-auth.yaml
@@ -20,7 +20,7 @@ data:
     - groups:
       - system:masters
       userarn: arn:aws:iam::405906814034:user/zlzlqlzl1@wafflestudio.com
-      username: jhvictor4@wafflestudio.com
+      username: zlzlqlzl1@wafflestudio.com
     - groups:
       - system:masters
       userarn: arn:aws:iam::405906814034:user/jhvictor4@wafflestudio.com

--- a/misc/kube-system/configmap/aws-auth.yaml
+++ b/misc/kube-system/configmap/aws-auth.yaml
@@ -1,0 +1,39 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: aws-auth
+  namespace: kube-system
+data:
+  mapRoles: |
+    - groups:
+      - system:bootstrappers
+      - system:nodes
+      rolearn: arn:aws:iam::405906814034:role/AmazonEKSNodeRole
+      username: system:node:{{EC2PrivateDNSName}}
+  mapUsers:
+    # cluster_creator: arn:aws:iam::405906814034:user/bdv111@wafflestudio.com
+    |
+    - groups:
+      - system:masters
+      userarn: arn:aws:iam::405906814034:user/jon.snow@wafflestudio.com
+      username: jon.snow@wafflestudio.com
+    - groups:
+      - system:masters
+      userarn: arn:aws:iam::405906814034:user/zlzlqlzl1@wafflestudio.com
+      username: jhvictor4@wafflestudio.com
+    - groups:
+      - system:masters
+      userarn: arn:aws:iam::405906814034:user/jhvictor4@wafflestudio.com
+      username: jhvictor4@wafflestudio.com
+    - groups:
+      - system:masters
+      userarn: arn:aws:iam::405906814034:user/marcel@wafflestudio.com
+      username: marcel@wafflestudio.com
+    - groups:
+      - system:masters
+      userarn: arn:aws:iam::405906814034:user/shp7724
+      username: shp7724
+    - groups:
+      - system:masters
+      userarn: arn:aws:iam::405906814034:user/ganzidaeyong@wafflestudio.com
+      username: ganzidaeyong@wafflestudio.com


### PR DESCRIPTION
참고: https://docs.aws.amazon.com/ko_kr/eks/latest/userguide/add-user-role.html

이미 `kubectl apply -f misc/kube-system/configmap/aws-auth.yaml`는 적용했고, 기록용으로 남깁니다. `misc` dir 내부는 commit 한다고 자동 반영되거나 하지 않습니다.

앞으로 이 사람들이 계속 `system:masters`을 갖는 것은 아니고, 일정 시점 후부터는 wafflestudio infra admin 분들만 남는 것으로 생각하면 됩니다.

cluster 생성자는 기본으로 `system:masters`을 갖는데, [aws guide](https://aws.amazon.com/ko/premiumsupport/knowledge-center/amazon-eks-cluster-access/) 에 굳이 명시하지 않는 게 가장 좋다고 해서, 저 자신을 주석으로만 명시했습니다.

**뭐든지 가능한 권한을 가지신 셈이므로, 주의해서 이용해주세요.**
