### PR TITLE
Set CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,7 +1,7 @@
 # https://help.github.com/articles/about-codeowners/
 
-* @davin111
+* @davin111 # @wafflestudio/waffle-k8s-admin
 apps/snutt-dev/ @wafflestudio/snutt-server
 apps/snutt-prod/ @wafflestudio/snutt-server
 apps/sso-dev/ @wafflestudio/sso
-apps/guam/ @wafflestudio/Guam
+apps/guam/ @wafflestudio/guam

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,7 @@
+# https://help.github.com/articles/about-codeowners/
+
+* @davin111
+apps/snutt-dev/ @wafflestudio/snutt-server
+apps/snutt-prod/ @wafflestudio/snutt-server
+apps/sso-dev/ @wafflestudio/sso
+apps/guam/ @wafflestudio/Guam


### PR DESCRIPTION
`*` 에 waffle-k8s-admin 를 안 넣은 이유는, 아직 초반이라 모든 노티 다 가면 annoying 할까봐입니다. 7명이나 되어서 좀 부담되는 것도 있고요. 안정화되면 주석 풀고 넣으면 될 거 같습니다.