### PR TITLE
Allow only swagger endpoint for prod snutt-ev

### DIFF
--- a/apps/snutt-prod/snutt-ev/snutt-ev.yaml
+++ b/apps/snutt-prod/snutt-ev/snutt-ev.yaml
@@ -65,6 +65,11 @@ spec:
   hosts:
   - snutt-ev-api.wafflestudio.com
   http:
-  - route:
+  - match:
+    - uri:
+        prefix: /swagger-ui
+    - uri:
+        prefix: /v3/api-docs
+    route:
     - destination:
         host: snutt-ev


### PR DESCRIPTION
prod snutt-core 도 eks 로 와서, cluster 내부 통신이 가능해졌으므로, `snutt-ev-api.wafflestudio.com`는 swagger 에 대해서만 접근할 수 있도록 하여 보안 강화