### PR TITLE
Grant snutt-dev, snutt-prod pod permissions to snutt members

### DIFF
--- a/misc/apps/snutt-dev/snutt-dev.yaml
+++ b/misc/apps/snutt-dev/snutt-dev.yaml
@@ -1,0 +1,25 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: pod-all-role
+  namespace: snutt-dev
+rules:
+- apiGroups: [""]
+  resources: ["pods"]
+  verbs: ["*"]
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: pod-all-role-binding
+  namespace: snutt-dev
+
+roleRef:
+  kind: Role
+  name: pod-all-role
+  apiGroup: rbac.authorization.k8s.io
+
+subjects:
+- kind: Group
+  apiGroup: rbac.authorization.k8s.io
+  name: snutt-developers

--- a/misc/apps/snutt-prod/snutt-prod.yaml
+++ b/misc/apps/snutt-prod/snutt-prod.yaml
@@ -1,0 +1,25 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: pod-all-role
+  namespace: snutt-prod
+rules:
+- apiGroups: [""]
+  resources: ["pods"]
+  verbs: ["*"]
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: pod-all-role-binding
+  namespace: snutt-prod
+
+roleRef:
+  kind: Role
+  name: pod-all-role
+  apiGroup: rbac.authorization.k8s.io
+
+subjects:
+- kind: Group
+  apiGroup: rbac.authorization.k8s.io
+  name: snutt-developers

--- a/misc/kube-system/configmap/aws-auth.yaml
+++ b/misc/kube-system/configmap/aws-auth.yaml
@@ -13,27 +13,33 @@ data:
   mapUsers:
     # cluster_creator: arn:aws:iam::405906814034:user/bdv111@wafflestudio.com
     |
-    - groups:
-      - system:masters
+    - username: jon.snow@wafflestudio.com
       userarn: arn:aws:iam::405906814034:user/jon.snow@wafflestudio.com
-      username: jon.snow@wafflestudio.com
-    - groups:
+      groups:
       - system:masters
+    - username: zlzlqlzl1@wafflestudio.com
       userarn: arn:aws:iam::405906814034:user/zlzlqlzl1@wafflestudio.com
-      username: zlzlqlzl1@wafflestudio.com
-    - groups:
+      groups:
       - system:masters
+      - snutt-developers
+    - username: jhvictor4@wafflestudio.com
       userarn: arn:aws:iam::405906814034:user/jhvictor4@wafflestudio.com
-      username: jhvictor4@wafflestudio.com
-    - groups:
+      groups:
       - system:masters
+    - username: marcel@wafflestudio.com
       userarn: arn:aws:iam::405906814034:user/marcel@wafflestudio.com
-      username: marcel@wafflestudio.com
-    - groups:
+      groups:
       - system:masters
+    - username: shp7724
       userarn: arn:aws:iam::405906814034:user/shp7724
-      username: shp7724
-    - groups:
+      groups:
       - system:masters
+    - username: ganzidaeyong@wafflestudio.com
       userarn: arn:aws:iam::405906814034:user/ganzidaeyong@wafflestudio.com
-      username: ganzidaeyong@wafflestudio.com
+      groups:
+      - system:masters
+    
+    - username: subeenpark-io
+      userarn: arn:aws:iam::405906814034:user/subeenpark-io
+      groups:
+      - snutt-developers

--- a/misc/kube-system/configmap/aws-auth.yaml
+++ b/misc/kube-system/configmap/aws-auth.yaml
@@ -43,3 +43,11 @@ data:
       userarn: arn:aws:iam::405906814034:user/subeenpark-io
       groups:
       - snutt-developers
+    - username: woohm404@wafflestudio.com
+      userarn: arn:aws:iam::405906814034:user/woohm404@wafflestudio.com
+      groups:
+      - snutt-developers
+    - username: ars-ki-00
+      userarn: arn:aws:iam::405906814034:user/ars-ki-00
+      groups:
+      - snutt-developers


### PR DESCRIPTION
snutt 팀 멤버들은 kubectl 이용을 원하는 경우가 있어서 권한 부여하고, [kubectl 이용 가이드](https://www.notion.so/wafflestudio/kubectl-WIP-c62498c8e7a042fba49fe94ed1143f02)를 대충 작성해보았습니다. 와플 전체에 대해 이렇게 할지는 고민이 더 필요할 거 같습니다. 의견 남겨주셔도 좋습니다.