### PR TITLE
allow all origins for truffle

### DIFF
--- a/apps/truffle-prod/truffle/truffle.yaml
+++ b/apps/truffle-prod/truffle/truffle.yaml
@@ -65,6 +65,15 @@ spec:
   hosts:
   - truffle-api.wafflestudio.com
   http:
-  - route:
-    - destination:
-        host: truffle
+    - corsPolicy:
+        allowHeaders:
+          - x-api-key
+          - content-type
+        allowMethods:
+          - POST
+          - OPTIONS
+        allowOrigin:
+          - "*"
+      route:
+        - destination:
+            host: truffle


### PR DESCRIPTION
지금 보니 `allowOrigin`도 되고 `allowOrigins`도 되는 거 같네요. 두 개가 문법이 다름.