### PR TITLE
[snu4t] Allow content-type header to allowHeaders of corsPolicy and Modify bookmarks routing

### DIFF
--- a/apps/snutt-dev/snutt-core/snutt-core.yaml
+++ b/apps/snutt-dev/snutt-core/snutt-core.yaml
@@ -62,6 +62,7 @@ spec:
   http:
     - corsPolicy:
         allowHeaders:
+          - content-type
           - x-access-apikey
           - x-access-token
         allowMethods:
@@ -81,8 +82,6 @@ spec:
             exact: GET
           uri:
             exact: /v1/tables
-        - uri:
-            regex: ^\/bookmarks(\/.*)?$
         - uri:
             regex: ^\/v1\/bookmarks(\/.*)?$
         - uri:

--- a/apps/truffle-prod/truffle/truffle.yaml
+++ b/apps/truffle-prod/truffle/truffle.yaml
@@ -67,8 +67,8 @@ spec:
   http:
     - corsPolicy:
         allowHeaders:
-          - x-api-key
           - content-type
+          - x-api-key
         allowMethods:
           - POST
           - OPTIONS


### PR DESCRIPTION
https://wafflestudio.slack.com/archives/C0PAVPS5T/p1674542012894069?thread_ts=1674539768.222069&cid=C0PAVPS5T

- content-type 이 x-www-urlencoded 가 아닌 json 인 경우 cors 이슈가 있어서 허용 header 로 추가해줘야함
- 신규 API 인 bookmarks 에 대해선 반드시 /v1/* 을 붙인 것만 받아줌
