### PR TITLE
prod snutt core routing & clusterip service

### DIFF
--- a/apps/snutt-dev/snutt-core/snutt-core.yaml
+++ b/apps/snutt-dev/snutt-core/snutt-core.yaml
@@ -60,41 +60,42 @@ spec:
   hosts:
     - snutt-api-dev.wafflestudio.com
   http:
-    - corsPolicy:
-        allowHeaders:
-          - content-type
-          - x-access-apikey
-          - x-access-token
-        allowMethods:
-          - POST
-          - GET
-          - PUT
-          - DELETE
-          - OPTIONS
-        allowOrigins:
-          - exact: 'https://snutt-dev.wafflestudio.com'
-      match:
-        - method:
-            exact: GET
-          uri:
-            exact: /tables
-        - method:
-            exact: GET
-          uri:
-            exact: /v1/tables
-        - uri:
-            regex: ^\/v1\/bookmarks(\/.*)?$
-        - uri:
-            exact: /auth/register_local
-        - uri:
-            exact: /v1/auth/register_local
-      name: snut4t-route
-      route:
-        - destination:
-            host: snutt-timetable
-    - route:
-        - destination:
-            host: snutt-core
+  - name: "snutt-core-route"
+    route:
+    - destination:
+        host: snutt-core
+  - name: "snutt-timetable-route"
+    match:
+    - method:
+        exact: GET
+      uri:
+        exact: /tables
+    - method:
+        exact: GET
+      uri:
+        exact: /v1/tables
+    - uri:
+        regex: ^\/v1\/bookmarks(\/.*)?$
+    - uri:
+        exact: /auth/register_local
+    - uri:
+        exact: /v1/auth/register_local
+    route:
+    - destination:
+        host: snutt-timetable
+    corsPolicy:
+      allowHeaders:
+      - content-type
+      - x-access-apikey
+      - x-access-token
+      allowMethods:
+      - POST
+      - GET
+      - PUT
+      - DELETE
+      - OPTIONS
+      allowOrigins:
+      - exact: 'https://snutt-dev.wafflestudio.com'
 ---
 apiVersion: batch/v1beta1
 kind: CronJob

--- a/apps/snutt-dev/snutt-ev-web/snutt-ev-web.yaml
+++ b/apps/snutt-dev/snutt-ev-web/snutt-ev-web.yaml
@@ -33,7 +33,7 @@ metadata:
   namespace: snutt-dev
   name: snutt-ev-web
 spec:
-  type: NodePort
+  type: ClusterIP
   selector:
     app: snutt-ev-web
   ports:

--- a/apps/snutt-dev/snutt-ev/snutt-ev.yaml
+++ b/apps/snutt-dev/snutt-ev/snutt-ev.yaml
@@ -47,7 +47,7 @@ metadata:
   namespace: snutt-dev
   name: snutt-ev
 spec:
-  type: NodePort
+  type: ClusterIP
   selector:
     app: snutt-ev
   ports:

--- a/apps/snutt-prod/snutt-core/snutt-core.yaml
+++ b/apps/snutt-prod/snutt-core/snutt-core.yaml
@@ -42,7 +42,7 @@ metadata:
   namespace: snutt-prod
   name: snutt-core
 spec:
-  type: NodePort
+  type: ClusterIP
   selector:
     app: snutt-core
   ports:
@@ -60,6 +60,13 @@ spec:
   hosts:
   - snutt-api.wafflestudio.com
   http:
+  - match:
+    - uri:
+        regex: ^\/v1\/bookmarks(\/.*)?$
+      name: snut4t-route
+      route:
+      - destination:
+          host: snutt-timetable
   - route:
     - destination:
         host: snutt-core

--- a/apps/snutt-prod/snutt-core/snutt-core.yaml
+++ b/apps/snutt-prod/snutt-core/snutt-core.yaml
@@ -60,16 +60,17 @@ spec:
   hosts:
   - snutt-api.wafflestudio.com
   http:
-  - match:
-    - uri:
-        regex: ^\/v1\/bookmarks(\/.*)?$
-      name: snut4t-route
-      route:
-      - destination:
-          host: snutt-timetable
-  - route:
+  - name: "snutt-core-route"
+    route:
     - destination:
         host: snutt-core
+  - name: "snutt-timetable-route"
+    match:
+    - uri:
+        regex: ^\/v1\/bookmarks(\/.*)?$
+    route:
+    - destination:
+        host: snutt-timetable
 ---
 apiVersion: batch/v1beta1
 kind: CronJob

--- a/apps/snutt-prod/snutt-ev-web/snutt-ev-web.yaml
+++ b/apps/snutt-prod/snutt-ev-web/snutt-ev-web.yaml
@@ -33,7 +33,7 @@ metadata:
   namespace: snutt-prod
   name: snutt-ev-web
 spec:
-  type: NodePort
+  type: ClusterIP
   selector:
     app: snutt-ev-web
   ports:

--- a/apps/snutt-prod/snutt-ev/snutt-ev.yaml
+++ b/apps/snutt-prod/snutt-ev/snutt-ev.yaml
@@ -47,7 +47,7 @@ metadata:
   namespace: snutt-prod
   name: snutt-ev
 spec:
-  type: NodePort
+  type: ClusterIP
   selector:
     app: snutt-ev
   ports:


### PR DESCRIPTION
- snutt-prod 에서 bookmarks API 는 snutt-timetable 로 routing 하도록 변경
- VirtualService routing 마다 적절한 naming 부여

- NodePort 이던 snutt Service 들 ClusterIP 로 변경 (https://github.com/wafflestudio/waffle-world/pull/26#discussion_r1069320836)
