### PR TITLE
add pupuri

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -13,3 +13,4 @@ apps/webgam-dev/ @wafflestudio/interactive-web
 apps/feelin-dev/ @wafflestudio/music-sns
 apps/feelin-prod/ @wafflestudio/music-sns
 apps/siksha-prod/ @wafflestudio/siksha
+apps/pupuri/ @woohm402

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -13,4 +13,4 @@ apps/webgam-dev/ @wafflestudio/interactive-web
 apps/feelin-dev/ @wafflestudio/music-sns
 apps/feelin-prod/ @wafflestudio/music-sns
 apps/siksha-prod/ @wafflestudio/siksha
-apps/pupuri/ @woohm402
+apps/pupuri-prod/ @woohm402

--- a/apps/pupuri-prod/pupuri-bot.yaml
+++ b/apps/pupuri-prod/pupuri-bot.yaml
@@ -22,7 +22,7 @@ spec:
         app: pupuri-bot
     spec:
       containers:
-        - image: 405906814034.dkr.ecr.ap-northeast-2.amazonaws.com/pupuri-prod/pupuri-bot:3
+        - image: 405906814034.dkr.ecr.ap-northeast-2.amazonaws.com/pupuri-prod/pupuri-bot:6
           name: pupuri-bot
           ports:
             - containerPort: 3000

--- a/apps/pupuri-prod/pupuri-bot.yaml
+++ b/apps/pupuri-prod/pupuri-bot.yaml
@@ -4,7 +4,7 @@ metadata:
   name: pupuri-bot
   labels:
     app: pupuri-bot
-  namespace: pupuri
+  namespace: pupuri-prod
 spec:
   replicas: 1
   selector:
@@ -22,7 +22,7 @@ spec:
         app: pupuri-bot
     spec:
       containers:
-        - image: 405906814034.dkr.ecr.ap-northeast-2.amazonaws.com/pupuri/pupuri-bot:2
+        - image: 405906814034.dkr.ecr.ap-northeast-2.amazonaws.com/pupuri-prod/pupuri-bot:3
           name: pupuri-bot
           ports:
             - containerPort: 3000
@@ -30,7 +30,7 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  namespace: pupuri
+  namespace: pupuri-prod
   name: pupuri-bot
 spec:
   type: ClusterIP
@@ -43,7 +43,7 @@ spec:
 apiVersion: networking.istio.io/v1alpha3
 kind: VirtualService
 metadata:
-  namespace: pupuri
+  namespace: pupuri-prod
   name: pupuri-bot
 spec:
   gateways:

--- a/apps/pupuri/pupuri-bot.yaml
+++ b/apps/pupuri/pupuri-bot.yaml
@@ -1,0 +1,56 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: pupuri-bot
+  labels:
+    app: pupuri-bot
+  namespace: pupuri
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: pupuri-bot
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 25%
+  revisionHistoryLimit: 4
+  template:
+    metadata:
+      labels:
+        app: pupuri-bot
+    spec:
+      containers:
+        - image: 405906814034.dkr.ecr.ap-northeast-2.amazonaws.com/pupuri/pupuri-bot:2
+          name: pupuri-bot
+          ports:
+            - containerPort: 3000
+---
+apiVersion: v1
+kind: Service
+metadata:
+  namespace: pupuri
+  name: pupuri-bot
+spec:
+  type: ClusterIP
+  selector:
+    app: pupuri-bot
+  ports:
+    - port: 80
+      targetPort: 3000
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  namespace: pupuri
+  name: pupuri-bot
+spec:
+  gateways:
+    - istio-ingress/waffle-ingressgateway
+  hosts:
+    - pupuri.wafflestudio.com
+  http:
+    - route:
+        - destination:
+            host: pupuri-bot

--- a/apps/pupuri/pupuri-bot.yaml
+++ b/apps/pupuri/pupuri-bot.yaml
@@ -49,7 +49,7 @@ spec:
   gateways:
     - istio-ingress/waffle-ingressgateway
   hosts:
-    - pupuri.wafflestudio.com
+    - pupuri-api.wafflestudio.com
   http:
     - route:
         - destination:

--- a/apps/templates/pupuri-bot.yaml
+++ b/apps/templates/pupuri-bot.yaml
@@ -1,0 +1,17 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  namespace: argocd
+  name: pupuri-bot
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: default
+  source:
+    repoURL: { { .Values.spec.source.repoURL } }
+    targetRevision: HEAD
+    path: apps/pupuri/pupuri-bot
+  destination:
+    server: { { .Values.spec.destination.server } }
+    namespace: argocd
+  syncPolicy: { { - .Values.spec.syncPolicy | toYaml | nindent 4 } }

--- a/apps/templates/pupuri-bot.yaml
+++ b/apps/templates/pupuri-bot.yaml
@@ -10,7 +10,7 @@ spec:
   source:
     repoURL: { { .Values.spec.source.repoURL } }
     targetRevision: HEAD
-    path: apps/pupuri/pupuri-bot
+    path: apps/pupuri-prod/pupuri-bot
   destination:
     server: { { .Values.spec.destination.server } }
     namespace: argocd


### PR DESCRIPTION
pupuri slackbot 을 추가합니다. snutt-ev-web-dev 의 것을 많이 참고했습니다.

- [ECR](https://ap-northeast-2.console.aws.amazon.com/ecr/repositories/private/405906814034/pupuri/pupuri-bot?region=ap-northeast-2)
- [slack request](https://wafflestudio.slack.com/archives/C01M4TMNFPX/p1679928566139959)
- [`#project-pupuri` slack channel](https://wafflestudio.slack.com/archives/C05021XHMQV)