### PR TITLE
Enclose kube-prometheus-stack chart && Use github sso

### DIFF
--- a/charts/prometheus/Chart.lock
+++ b/charts/prometheus/Chart.lock
@@ -1,12 +1,6 @@
 dependencies:
-- name: kube-state-metrics
+- name: kube-prometheus-stack
   repository: https://prometheus-community.github.io/helm-charts
-  version: 4.22.3
-- name: prometheus-node-exporter
-  repository: https://prometheus-community.github.io/helm-charts
-  version: 4.4.2
-- name: grafana
-  repository: https://grafana.github.io/helm-charts
-  version: 6.43.5
-digest: sha256:8c89e97ec8b047148f377703f0452b72ce49d675374ee11ba6bc503df59231d0
-generated: "2022-11-11T08:29:54.338236+01:00"
+  version: 42.0.2
+digest: sha256:929d5fe61fc89586509758f1ff091e7ed5be394d46efec7b5c67b480504c49ac
+generated: "2023-05-01T14:40:29.662296+09:00"

--- a/charts/prometheus/Chart.yaml
+++ b/charts/prometheus/Chart.yaml
@@ -1,16 +1,7 @@
 apiVersion: v2
 name: kube-prometheus-stack
-version: 42.0.2
+version: 1.0.0
 dependencies:
-- condition: kubeStateMetrics.enabled
-  name: kube-state-metrics
+- name: kube-prometheus-stack
+  version: 42.0.2
   repository: https://prometheus-community.github.io/helm-charts
-  version: 4.22.*
-- condition: nodeExporter.enabled
-  name: prometheus-node-exporter
-  repository: https://prometheus-community.github.io/helm-charts
-  version: 4.4.*
-- condition: grafana.enabled
-  name: grafana
-  repository: https://grafana.github.io/helm-charts
-  version: 6.43.*

--- a/charts/prometheus/values.yaml
+++ b/charts/prometheus/values.yaml
@@ -1,73 +1,87 @@
 ## Using default values from https://github.com/grafana/helm-charts/blob/main/charts/grafana/values.yaml
 ##
-grafana:
-  enabled: true
-  defaultDashboardsTimezone: Asia/Seoul
-  adminPassword: #
+kube-prometheus-stack:
+  grafana:
+    enabled: true
+    defaultDashboardsTimezone: Asia/Seoul
+    adminPassword: # secret
+    grafana.ini:
+      server:
+        root_url: https://grafana.wafflestudio.com
+      auth.github:
+        enabled: true
+        allow_sign_up: true
+        scopes: user:email,read:org
+        auth_url: https://github.com/login/oauth/authorize
+        token_url: https://github.com/login/oauth/access_token
+        api_url: https://api.github.com/user
+        allowed_organizations: wafflestudio
+        client_id: 75c8b088348e91be1e97
+        client_secret: # secret
 
-## Deploy a Prometheus instance
-##
-prometheus:
-  enabled: true
-
-  ## Settings affecting prometheusSpec
-  ## ref: https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#prometheusspec
+  ## Deploy a Prometheus instance
   ##
-  prometheusSpec:
-    ## How long to retain metrics
+  prometheus:
+    enabled: true
+
+    ## Settings affecting prometheusSpec
+    ## ref: https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#prometheusspec
     ##
-    retention: 10d
-    resources:
-      requests:
-        memory: 400Mi
-      limits:
-        memory: 1Gi
-    additionalScrapeConfigs:
-      - job_name: 'istiod'
-        kubernetes_sd_configs:
-          - role: endpoints
-            namespaces:
-              names:
-                - istio-system
-        relabel_configs:
-          - source_labels: [ __meta_kubernetes_service_name, __meta_kubernetes_endpoint_port_name ]
-            action: keep
-            regex: istiod;http-monitoring
-      - job_name: 'envoy-stats'
-        metrics_path: /stats/prometheus
-        kubernetes_sd_configs:
-          - role: pod
-        relabel_configs:
-          - source_labels: [ __meta_kubernetes_pod_container_port_name ]
-            action: keep
-            regex: '.*-envoy-prom'
-      - job_name: 'istio-mesh'
-        kubernetes_sd_configs:
-          - role: endpoints
-            namespaces:
-              names:
-                - istio-system
-        relabel_configs:
-          - source_labels: [ __meta_kubernetes_service_name, __meta_kubernetes_endpoint_port_name ]
-            action: keep
-            regex: istio-telemetry;prometheus
-      - job_name: 'istio-telemetry'
-        kubernetes_sd_configs:
-          - role: endpoints
-            namespaces:
-              names:
-                - istio-system
-        relabel_configs:
-          - source_labels: [ __meta_kubernetes_service_name, __meta_kubernetes_endpoint_port_name ]
-            action: keep
-            regex: istio-telemetry;http-monitoring
-      - job_name: 'istio-policy'
-        kubernetes_sd_configs:
-          - role: endpoints
-            namespaces:
-              names:
-                - istio-system
-        relabel_configs:
-          - source_labels: [ __meta_kubernetes_service_name, __meta_kubernetes_endpoint_port_name ]
-            action: keep
-            regex: istio-policy;http-policy-monitoring
+    prometheusSpec:
+      ## How long to retain metrics
+      ##
+      retention: 10d
+      resources:
+        requests:
+          memory: 400Mi
+        limits:
+          memory: 1Gi
+      additionalScrapeConfigs:
+        - job_name: 'istiod'
+          kubernetes_sd_configs:
+            - role: endpoints
+              namespaces:
+                names:
+                  - istio-system
+          relabel_configs:
+            - source_labels: [ __meta_kubernetes_service_name, __meta_kubernetes_endpoint_port_name ]
+              action: keep
+              regex: istiod;http-monitoring
+        - job_name: 'envoy-stats'
+          metrics_path: /stats/prometheus
+          kubernetes_sd_configs:
+            - role: pod
+          relabel_configs:
+            - source_labels: [ __meta_kubernetes_pod_container_port_name ]
+              action: keep
+              regex: '.*-envoy-prom'
+        - job_name: 'istio-mesh'
+          kubernetes_sd_configs:
+            - role: endpoints
+              namespaces:
+                names:
+                  - istio-system
+          relabel_configs:
+            - source_labels: [ __meta_kubernetes_service_name, __meta_kubernetes_endpoint_port_name ]
+              action: keep
+              regex: istio-telemetry;prometheus
+        - job_name: 'istio-telemetry'
+          kubernetes_sd_configs:
+            - role: endpoints
+              namespaces:
+                names:
+                  - istio-system
+          relabel_configs:
+            - source_labels: [ __meta_kubernetes_service_name, __meta_kubernetes_endpoint_port_name ]
+              action: keep
+              regex: istio-telemetry;http-monitoring
+        - job_name: 'istio-policy'
+          kubernetes_sd_configs:
+            - role: endpoints
+              namespaces:
+                names:
+                  - istio-system
+          relabel_configs:
+            - source_labels: [ __meta_kubernetes_service_name, __meta_kubernetes_endpoint_port_name ]
+              action: keep
+              regex: istio-policy;http-policy-monitoring


### PR DESCRIPTION
1. waffle-world 의 다른 charts 들처럼, `kube-prometheus-stack` helm chart 를 감싼 chart 를 정의해서 사용함.
2. grafana 에 github sso 를 적용함. (기존 admin pwd 는 좀 공유가 되어서 변경함.)

(이미 이 방식으로 chart 재설치 해본 상태입니다. https://grafana.wafflestudio.com )