### PR TITLE
[FEATURE] ServiceAccount 추가: DB 연결용 SecretsManager 권한 role

### DIFF
--- a/apps/ggzz-dev/ggzz-server/ggzz-server.yaml
+++ b/apps/ggzz-dev/ggzz-server/ggzz-server.yaml
@@ -28,6 +28,14 @@ spec:
             - containerPort: 8080
 ---
 apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: ggzz-server
+  namespace: ggzz-dev
+  annotations:
+    eks.amazonaws.com/role-arn: arn:aws:iam::405906814034:role/ggzz-dev-role
+---
+apiVersion: v1
 kind: Service
 metadata:
   namespace: ggzz-dev

--- a/apps/ggzz-dev/ggzz-server/ggzz-server.yaml
+++ b/apps/ggzz-dev/ggzz-server/ggzz-server.yaml
@@ -21,6 +21,7 @@ spec:
       labels:
         app: ggzz-server
     spec:
+      serviceAccountName: ggzz-server
       containers:
         - image: 405906814034.dkr.ecr.ap-northeast-2.amazonaws.com/ggzz-dev/ggzz-server:4
           name: ggzz-server


### PR DESCRIPTION
- DB instance 정보 받아 local에서 연결 및 db/user 생성 후 관련 정보를 AWS Secrets Manager에 등록
    1. `GgzzSecurityGroup` 생성 후 inbound로 192.168.0.0/16 (wafflestudio-vpc), outbound로 All traffic 열기
    2. db 생성 / user 생성
    3. dev/ggzz-server에 AWS RDS(mysql) user / password 등록
    4. `GgzzSecretsManagerDev` Policy 생성 후 `ggzz-dev-role`에 부여
    5. DB에 `ggzz-server` Deployment가 띄우는 image가 바라볼 수 있도록 ServiceAccount를 `waffle-world` manifest에 정의