### PR TITLE
Add istio-util app to ArgoCD (for EnvoyFilter)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,6 +1,7 @@
 # https://help.github.com/articles/about-codeowners/
 
 * @davin111 @wafflestudio/waffle-k8s-admin
+apps/istio-util/ @wafflestudio/waffle-k8s-admin
 apps/snutt-dev/ @wafflestudio/snutt-server
 apps/snutt-dev/snutt-ev-web/ @wafflestudio/snutt-frontend
 apps/snutt-prod/ @wafflestudio/snutt-server

--- a/apps/istio-util/istio-util/snutt-envoy-filter.yaml
+++ b/apps/istio-util/istio-util/snutt-envoy-filter.yaml
@@ -1,0 +1,63 @@
+apiVersion: networking.istio.io/v1alpha3
+kind: EnvoyFilter
+metadata:
+  namespace: istio-ingress
+  name: dev-snutt-trailing-slash-filter
+spec:
+  configPatches:
+  - applyTo: HTTP_ROUTE
+    match:
+      context: GATEWAY
+      routeConfiguration:
+        vhost:
+          route:
+            name: dev-snutt-timetable-route
+    patch:
+      operation: MERGE
+      value:
+        name: envoy.lua
+        typed_per_filter_config:
+          envoy.filters.http.lua:
+            '@type': type.googleapis.com/envoy.extensions.filters.http.lua.v3.LuaPerRoute
+            source_code:
+              inline_string: |
+                function envoy_on_request(request_handle)
+                  local path = request_handle:headers():get(":path")
+                  local path_without_trailing_slash = string.match(path, "(.*)/$")
+                  if path_without_trailing_slash ~= nil
+                  then
+                    request_handle:headers():replace(":path", path_without_trailing_slash)
+                  end
+                end
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: EnvoyFilter
+metadata:
+  namespace: istio-ingress
+  name: prod-snutt-trailing-slash-filter
+spec:
+  configPatches:
+  - applyTo: HTTP_ROUTE
+    match:
+      context: GATEWAY
+      routeConfiguration:
+        vhost:
+          route:
+            name: prod-snutt-timetable-route
+    patch:
+      operation: MERGE
+      value:
+        name: envoy.lua
+        typed_per_filter_config:
+          envoy.filters.http.lua:
+            '@type': type.googleapis.com/envoy.extensions.filters.http.lua.v3.LuaPerRoute
+            source_code:
+              inline_string: |
+                function envoy_on_request(request_handle)
+                  local path = request_handle:headers():get(":path")
+                  local path_without_trailing_slash = string.match(path, "(.*)/$")
+                  if path_without_trailing_slash ~= nil
+                  then
+                    request_handle:headers():replace(":path", path_without_trailing_slash)
+                  end
+                end

--- a/apps/snutt-dev/snutt-core/snutt-core.yaml
+++ b/apps/snutt-dev/snutt-core/snutt-core.yaml
@@ -60,7 +60,7 @@ spec:
   hosts:
     - snutt-api-dev.wafflestudio.com
   http:
-  - name: "snutt-timetable-route"
+  - name: "dev-snutt-timetable-route"
     match:
     - method:
         exact: GET
@@ -98,55 +98,3 @@ spec:
     route:
     - destination:
         host: snutt-core
----
-# https://istio.io/latest/docs/reference/config/networking/envoy-filter/#EnvoyFilter-RouteConfigurationMatch-RouteMatch
-apiVersion: networking.istio.io/v1alpha3
-kind: EnvoyFilter
-metadata:
-  namespace: istio-ingress
-  name: dev-snutt-trailing-slash-filter
-spec:
-  configPatches:
-  - applyTo: HTTP_FILTER
-    match:
-      listener:
-        filterChain:
-          filter:
-            name: envoy.filters.network.http_connection_manager
-            subFilter:
-              name: envoy.filters.http.router
-    patch:
-      operation: INSERT_BEFORE
-      value:
-        name: envoy.lua
-        typed_config:
-          '@type': type.googleapis.com/envoy.extensions.filters.http.lua.v3.Lua
-          inlineCode: |
-            function envoy_on_request(request_handle)
-              -- Empty lua function
-            end
-  - applyTo: HTTP_ROUTE
-    match:
-      context: GATEWAY
-      routeConfiguration:
-        vhost:
-          route:
-            name: snutt-timetable-route
-    patch:
-      operation: MERGE
-      value:
-        name: envoy.lua
-        typed_per_filter_config:
-          envoy.filters.http.lua:
-            '@type': type.googleapis.com/envoy.extensions.filters.http.lua.v3.LuaPerRoute
-            source_code:
-              inline_string: |
-                function envoy_on_request(request_handle)
-                  local path = request_handle:headers():get(":path")
-                  local path_without_trailing_slash = string.match(path, "(.*)/$")
-                  if path_without_trailing_slash ~= nil
-                  then
-                    request_handle:headers():replace(":path", path_without_trailing_slash)
-                  end
-                end
-

--- a/apps/snutt-prod/snutt-core/snutt-core.yaml
+++ b/apps/snutt-prod/snutt-core/snutt-core.yaml
@@ -60,7 +60,7 @@ spec:
   hosts:
   - snutt-api.wafflestudio.com
   http:
-  - name: "snutt-timetable-route"
+  - name: "prod-snutt-timetable-route"
     match:
     - uri:
         regex: ^\/v1\/bookmarks(\/.*)?$

--- a/apps/templates/istio-util.yaml
+++ b/apps/templates/istio-util.yaml
@@ -1,0 +1,18 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  namespace: argocd
+  name: istio-util
+  finalizers:
+  - resources-finalizer.argocd.argoproj.io
+spec:
+  project: default
+  source:
+    repoURL: {{ .Values.spec.source.repoURL }}
+    targetRevision: HEAD
+    path: apps/istio-util/istio-util
+  destination:
+    server: {{ .Values.spec.destination.server }}
+    namespace: argocd
+  syncPolicy:
+    {{- .Values.spec.syncPolicy | toYaml | nindent 4 }}


### PR DESCRIPTION
EnvoyFilter 를 편하게 관리하기 위해 ArgoCD 앱으로서 추가 이동하면서,

기존에 의도치 않게 dev 와 prod snutt 모두에 적용되던 것을 명확하게 분리.