### PR TITLE
TRUFFLE_ENABLED=true for snutt-ev, snu4t

### DIFF
--- a/apps/snutt-dev/snutt-ev-batch/snutt-ev-batch.yaml
+++ b/apps/snutt-dev/snutt-ev-batch/snutt-ev-batch.yaml
@@ -29,6 +29,8 @@ spec:
               value: "-Duser.timezone=UTC"
             - name: SPRING_PROFILES_ACTIVE
               value: "dev"
+            - name: TRUFFLE_ENABLED
+              value: "true"
 ---
 apiVersion: batch/v1beta1
 kind: CronJob
@@ -65,6 +67,8 @@ spec:
               value: "-Duser.timezone=UTC"
             - name: SPRING_PROFILES_ACTIVE
               value: "dev"
+            - name: TRUFFLE_ENABLED
+              value: "true"
 ---
 apiVersion: v1
 kind: ServiceAccount

--- a/apps/snutt-dev/snutt-ev/snutt-ev.yaml
+++ b/apps/snutt-dev/snutt-ev/snutt-ev.yaml
@@ -32,6 +32,8 @@ spec:
           value: "-Duser.timezone=UTC"
         - name: SPRING_PROFILES_ACTIVE
           value: "dev"
+        - name: TRUFFLE_ENABLED
+          value: "true"
 ---
 apiVersion: v1
 kind: ServiceAccount

--- a/apps/snutt-dev/snutt-timetable-batch/snutt-timetable-batch.yaml
+++ b/apps/snutt-dev/snutt-timetable-batch/snutt-timetable-batch.yaml
@@ -29,6 +29,8 @@ spec:
               value: "-Duser.timezone=UTC"
             - name: SPRING_PROFILES_ACTIVE
               value: "dev"
+            - name: TRUFFLE_ENABLED
+              value: "true"
 ---
 apiVersion: batch/v1beta1
 kind: CronJob
@@ -61,6 +63,8 @@ spec:
               value: "-Duser.timezone=UTC"
             - name: SPRING_PROFILES_ACTIVE
               value: "dev"
+            - name: TRUFFLE_ENABLED
+              value: "true"
 ---
 apiVersion: v1
 kind: ServiceAccount

--- a/apps/snutt-dev/snutt-timetable/snutt-timetable.yaml
+++ b/apps/snutt-dev/snutt-timetable/snutt-timetable.yaml
@@ -32,6 +32,8 @@ spec:
           value: "-Duser.timezone=UTC"
         - name: SPRING_PROFILES_ACTIVE
           value: "dev"
+        - name: TRUFFLE_ENABLED
+          value: "true"
 ---
 apiVersion: v1
 kind: ServiceAccount

--- a/apps/snutt-prod/snutt-ev-batch/snutt-ev-batch.yaml
+++ b/apps/snutt-prod/snutt-ev-batch/snutt-ev-batch.yaml
@@ -29,6 +29,8 @@ spec:
               value: "-Duser.timezone=UTC"
             - name: SPRING_PROFILES_ACTIVE
               value: "prod"
+            - name: TRUFFLE_ENABLED
+              value: "true"
 ---
 apiVersion: batch/v1beta1
 kind: CronJob
@@ -64,6 +66,8 @@ spec:
               value: "-Duser.timezone=UTC"
             - name: SPRING_PROFILES_ACTIVE
               value: "prod"
+            - name: TRUFFLE_ENABLED
+              value: "true"
 ---
 apiVersion: v1
 kind: ServiceAccount

--- a/apps/snutt-prod/snutt-ev/snutt-ev.yaml
+++ b/apps/snutt-prod/snutt-ev/snutt-ev.yaml
@@ -32,6 +32,8 @@ spec:
           value: "-Duser.timezone=UTC"
         - name: SPRING_PROFILES_ACTIVE
           value: "prod"
+        - name: TRUFFLE_ENABLED
+          value: "true"
 ---
 apiVersion: v1
 kind: ServiceAccount

--- a/apps/snutt-prod/snutt-timetable-batch/snutt-timetable-batch.yaml
+++ b/apps/snutt-prod/snutt-timetable-batch/snutt-timetable-batch.yaml
@@ -29,6 +29,8 @@ spec:
               value: "-Duser.timezone=UTC"
             - name: SPRING_PROFILES_ACTIVE
               value: "prod"
+            - name: TRUFFLE_ENABLED
+              value: "true"
 ---
 apiVersion: v1
 kind: ServiceAccount

--- a/apps/snutt-prod/snutt-timetable/snutt-timetable.yaml
+++ b/apps/snutt-prod/snutt-timetable/snutt-timetable.yaml
@@ -32,6 +32,8 @@ spec:
           value: "-Duser.timezone=UTC"
         - name: SPRING_PROFILES_ACTIVE
           value: "prod"
+        - name: TRUFFLE_ENABLED
+          value: "true"
 ---
 apiVersion: v1
 kind: ServiceAccount


### PR DESCRIPTION
https://wafflestudio.slack.com/archives/C04T7UW3U8G/p1683450147942169?thread_ts=1683449967.142629&cid=C04T7UW3U8G

로컬에서 dev profile 로 개발하는 경우가 있는데, application.yml 에 설정해두면 로컬 에러가 false alert 로 슬랙에 오는 경우가 있어서, application.yml 설정에선 빼고, 배포 환경의 환경 변수로 설정해서, k8s 환경에서만 truffle-kotlin sdk 동작하게 함.