### PR TITLE
[suggestion] replace prometheus storage from EmptyDir to PVC

### DIFF
--- a/charts/prometheus/values.yaml
+++ b/charts/prometheus/values.yaml
@@ -36,6 +36,15 @@ kube-prometheus-stack:
           memory: 400Mi
         limits:
           memory: 1Gi
+      storage:
+        volumeClaimTemplate:
+          spec:
+            # fixme (?) default storage class (aws ebs)
+            storageClassName: gp2
+            accessModes: [ "ReadWriteOnce" ]
+            resources:
+              requests:
+              storage: 20Gi
       additionalScrapeConfigs:
         - job_name: 'istiod'
           kubernetes_sd_configs:

--- a/charts/prometheus/values.yaml
+++ b/charts/prometheus/values.yaml
@@ -39,7 +39,6 @@ kube-prometheus-stack:
       storage:
         volumeClaimTemplate:
           spec:
-            # fixme (?) default storage class (aws ebs)
             storageClassName: gp2
             accessModes: [ "ReadWriteOnce" ]
             resources:


### PR DESCRIPTION
## 배경

프로메테우스 스토리지가 기본 세팅 (EmptyDir) 사용, 파드 재시작 시 유실 위험이 있었음
PV 사용하도록 설정하면 좋겠다 싶었음

## 해결 방법

`prometheus-kube-prometheus-prometheus` 서비스의 파드 조회하고 디비 볼륨 & 마운트 상황 파악해봄

https://grafana.wafflestudio.com/ 에서 볼륨 사용량이 보이지 않아서 (찾지 못해서)
아래 방법으로 조회 후 설정 그대로 config에 넣어봤어요

```
➜  ~ kc describe pod prometheus-prometheus-kube-prometheus-prometheus-0 -n prometheus

    Mounts:
      /etc/prometheus/certs from tls-assets (ro)
      /etc/prometheus/config_out from config-out (ro)
      /etc/prometheus/rules/prometheus-prometheus-kube-prometheus-prometheus-rulefiles-0 from prometheus-prometheus-kube-prometheus-prometheus-rulefiles-0 (rw)
      /etc/prometheus/web_config/web-config.yaml from web-config (ro,path="web-config.yaml")
      /prometheus from prometheus-prometheus-kube-prometheus-prometheus-db (rw)
      /var/run/secrets/kubernetes.io/serviceaccount from kube-api-access-x7qpt (ro)
Volumes:
  prometheus-prometheus-kube-prometheus-prometheus-db:
    Type:       EmptyDir (a temporary directory that shares a pod's lifetime)
    Medium:
    SizeLimit:  <unset>
```

`prometheus-prometheus-kube-prometheus-prometheus-db` 볼륨 마운트 경로 = `/prometheus`
파드 들어가서 얼마나 쓰는지 체크

```
➜  ~ kc exec -it -n prometheus prometheus-prometheus-kube-prometheus-prometheus-0 -- /bin/sh
/prometheus $ df -h
Filesystem                Size      Used Available Use% Mounted on
overlay                  20.0G     12.2G      7.8G  61% /
tmpfs                    64.0M         0     64.0M   0% /dev
tmpfs                     1.9G         0      1.9G   0% /sys/fs/cgroup
/dev/nvme0n1p1           20.0G     12.2G      7.8G  61% /prometheus
/dev/nvme0n1p1           20.0G     12.2G      7.8G  61% /dev/termination-log
/dev/nvme0n1p1           20.0G     12.2G      7.8G  61% /etc/hostname
/dev/nvme0n1p1           20.0G     12.2G      7.8G  61% /etc/hosts
shm                      64.0M         0     64.0M   0% /dev/shm
/dev/nvme0n1p1           20.0G     12.2G      7.8G  61% /etc/resolv.conf
/dev/nvme0n1p1           20.0G     12.2G      7.8G  61% /etc/prometheus/config_out
tmpfs                     1.0G      4.0K      1.0G   0% /etc/prometheus/certs
/dev/nvme0n1p1           20.0G     12.2G      7.8G  61% /etc/prometheus/rules/prometheus-prometheus-kube-prometheus-prometheus-rulefiles-0
tmpfs                     1.0G         0      1.0G   0% /etc/prometheus/web_config/web-config.yaml
tmpfs                     1.0G     12.0K      1.0G   0% /var/run/secrets/kubernetes.io/serviceaccount
tmpfs                     1.9G         0      1.9G   0% /proc/acpi
tmpfs                    64.0M         0     64.0M   0% /proc/kcore
tmpfs                    64.0M         0     64.0M   0% /proc/keys
tmpfs                    64.0M         0     64.0M   0% /proc/latency_stats
tmpfs                    64.0M         0     64.0M   0% /proc/timer_list
tmpfs                    64.0M         0     64.0M   0% /proc/sched_debug
tmpfs                     1.9G         0      1.9G   0% /sys/firmware
```

12.2Gi 정도 쓰는 것 확인
클러스터 내 존재하는 StorageClass 확인 후 사용 설정

## 특이사항

EBS I/O 관련해서 비용이 많이 나갈 것 같습니다.
설정값이랑 같이 검토부터 우선 해보면 좋을 것 같아 올려보았습니다. 

---

+ 근데 PVC 177일 전에 누가 만들어놓았고 bound 되어있던데, 실제로 deployment에는 안 쓰이고 있었음
요거 이것저것 해보는 와중에 생긴 것들일까요?

```
➜  ~ kc get pvc -n prometheus
NAME                                                                                                     STATUS    VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS   AGE
prometheus-prometheus-kube-prometheus-prometheus-db-prometheus-prometheus-kube-prometheus-prometheus-0   Pending                                                                        gluster        177d
prometheus-prometheus-kube-prometheus-prometheus-db-prometheus-prometheus-kube-prometheus-prometheus-1   Bound     pvc-ca753c65-47f0-43d3-9d1e-af04c44f78f0   10Gi       RWO            gp2            177d
```