### PR TITLE
truffle-dashboard 서버를 kong-gateway 뒤에 위치시키기

### DIFF
--- a/apps/sso-prod/kong-gateway/kong-config.yaml
+++ b/apps/sso-prod/kong-gateway/kong-config.yaml
@@ -14,3 +14,14 @@ services:
     - /api/account-service/
   plugins:
   - name: waffle-jwt-authorizer
+
+- name: truffle-service
+  url: http://truffle-dashboard.truffle-prod.svc.cluster.local
+  routes:
+  - name: truffle-web-cf
+    hosts:
+      - truffle.wafflestudio.com
+    paths:
+      - /api/
+  plugins:
+    - name: waffle-jwt-authorizer

--- a/apps/sso-prod/kong-gateway/kong-config.yaml
+++ b/apps/sso-prod/kong-gateway/kong-config.yaml
@@ -20,8 +20,8 @@ services:
   routes:
   - name: truffle-web-cf
     hosts:
-      - truffle.wafflestudio.com
+    - truffle.wafflestudio.com
     paths:
-      - /api/
+    - /api/
   plugins:
-    - name: waffle-jwt-authorizer
+  - name: waffle-jwt-authorizer

--- a/apps/sso-prod/kong-gateway/kong-gateway.yaml
+++ b/apps/sso-prod/kong-gateway/kong-gateway.yaml
@@ -102,6 +102,7 @@ spec:
   hosts:
   - api-gateway.wafflestudio.com
   - sso.wafflestudio.com
+  - truffle.wafflestudio.com
   http:
   - route:
     - destination:

--- a/apps/truffle-prod/truffle-dashboard/truffle-dashboard.yaml
+++ b/apps/truffle-prod/truffle-dashboard/truffle-dashboard.yaml
@@ -60,8 +60,6 @@ spec:
   http:
     - match:
         - uri:
-            prefix: /api
-        - uri:
             prefix: /swagger-ui
         - uri:
             prefix: /v3/api-docs


### PR DESCRIPTION
truffle.wafflestudio.com/api/* 요청이 kong-gateway (w/ waffle-jwt-authorizer plugin) 을 통해서 가도록 함