### PR TITLE
snutt-dev, snutt-prod resources requests/limits 설정 & istio-proxy limits 조절

### DIFF
--- a/apps/snutt-dev/snutt-core/snutt-core.yaml
+++ b/apps/snutt-dev/snutt-core/snutt-core.yaml
@@ -25,6 +25,13 @@ spec:
       containers:
       - image: 405906814034.dkr.ecr.ap-northeast-2.amazonaws.com/snutt-dev/snutt-core:151
         name: snutt-core
+        resources:
+          requests:
+            cpu: 100m
+            memory: 192Mi
+          limits:
+            cpu: 100m
+            memory: 192Mi
         ports:
         - containerPort: 3000
 ---

--- a/apps/snutt-dev/snutt-ev-batch/snutt-ev-batch.yaml
+++ b/apps/snutt-dev/snutt-ev-batch/snutt-ev-batch.yaml
@@ -22,11 +22,18 @@ spec:
           containers:
           - image: 405906814034.dkr.ecr.ap-northeast-2.amazonaws.com/snutt-dev/snutt-ev-batch:39
             name: snutt-ev-batch-lecture-sync
+            resources:
+              requests:
+                cpu: 200m
+                memory: 768Mi
+              limits:
+                cpu: 1000m
+                memory: 768Mi
             env:
             - name: JOB_NAME
               value: "SYNC_JOB"
             - name: JAVA_OPTS
-              value: "-Duser.timezone=UTC"
+              value: "-XX:InitialRAMPercentage=80.0 -XX:MaxRAMPercentage=80.0 -Duser.timezone=UTC"
             - name: SPRING_PROFILES_ACTIVE
               value: "dev"
             - name: TRUFFLE_ENABLED
@@ -60,11 +67,18 @@ spec:
           - image: 405906814034.dkr.ecr.ap-northeast-2.amazonaws.com/snutt-dev/snutt-ev-batch:39
             imagePullPolicy: IfNotPresent
             name: snutt-ev-batch-snuev-migration
+            resources:
+              requests:
+                cpu: 200m
+                memory: 768Mi
+              limits:
+                cpu: 1000m
+                memory: 768Mi
             env:
             - name: JOB_NAME
               value: "SNUEV_MIGRATION_JOB"
             - name: JAVA_OPTS
-              value: "-Duser.timezone=UTC"
+              value: "-XX:InitialRAMPercentage=80.0 -XX:MaxRAMPercentage=80.0 -Duser.timezone=UTC"
             - name: SPRING_PROFILES_ACTIVE
               value: "dev"
             - name: TRUFFLE_ENABLED

--- a/apps/snutt-dev/snutt-ev-web/snutt-ev-web.yaml
+++ b/apps/snutt-dev/snutt-ev-web/snutt-ev-web.yaml
@@ -24,6 +24,13 @@ spec:
       containers:
       - image: 405906814034.dkr.ecr.ap-northeast-2.amazonaws.com/snutt-dev/snutt-ev-web:247
         name: snutt-ev-web
+        resources:
+          requests:
+            cpu: 100m
+            memory: 192Mi
+          limits:
+            cpu: 100m
+            memory: 192Mi
         ports:
         - containerPort: 3000
 ---

--- a/apps/snutt-dev/snutt-ev/snutt-ev.yaml
+++ b/apps/snutt-dev/snutt-ev/snutt-ev.yaml
@@ -25,11 +25,18 @@ spec:
       containers:
       - image: 405906814034.dkr.ecr.ap-northeast-2.amazonaws.com/snutt-dev/snutt-ev:39
         name: snutt-ev
+        resources:
+          requests:
+            cpu: 100m
+            memory: 512Mi
+          limits:
+            cpu: 100m
+            memory: 512Mi
         ports:
         - containerPort: 8080
         env:
         - name: JAVA_OPTS
-          value: "-Duser.timezone=UTC"
+          value: "-XX:InitialRAMPercentage=80.0 -XX:MaxRAMPercentage=80.0 -Duser.timezone=UTC"
         - name: SPRING_PROFILES_ACTIVE
           value: "dev"
         - name: TRUFFLE_ENABLED

--- a/apps/snutt-dev/snutt-timetable-batch/snutt-timetable-batch.yaml
+++ b/apps/snutt-dev/snutt-timetable-batch/snutt-timetable-batch.yaml
@@ -22,11 +22,18 @@ spec:
           containers:
           - image: 405906814034.dkr.ecr.ap-northeast-2.amazonaws.com/snutt-dev/snutt-timetable-batch:98
             name: snutt-timetable-batch-coursebook
+            resources:
+              requests:
+                cpu: 200m
+                memory: 768Mi
+              limits:
+                cpu: 1000m
+                memory: 768Mi
             env:
             - name: JOB_NAME
               value: "sugangSnuMigrationJob"
             - name: JAVA_OPTS
-              value: "-Duser.timezone=UTC"
+              value: "-XX:InitialRAMPercentage=80.0 -XX:MaxRAMPercentage=80.0 -Duser.timezone=UTC"
             - name: SPRING_PROFILES_ACTIVE
               value: "dev"
             - name: TRUFFLE_ENABLED
@@ -56,11 +63,18 @@ spec:
           containers:
           - image: 405906814034.dkr.ecr.ap-northeast-2.amazonaws.com/snutt-dev/snutt-timetable-batch:98
             name: snutt-timetable-batch-seat-noti
+            resources:
+              requests:
+                cpu: 200m
+                memory: 768Mi
+              limits:
+                cpu: 1000m
+                memory: 768Mi
             env:
             - name: JOB_NAME
               value: "vacancyNotificationJob"
             - name: JAVA_OPTS
-              value: "-Duser.timezone=UTC"
+              value: "-XX:InitialRAMPercentage=80.0 -XX:MaxRAMPercentage=80.0 -Duser.timezone=UTC"
             - name: SPRING_PROFILES_ACTIVE
               value: "dev"
             - name: TRUFFLE_ENABLED

--- a/apps/snutt-dev/snutt-timetable/snutt-timetable.yaml
+++ b/apps/snutt-dev/snutt-timetable/snutt-timetable.yaml
@@ -25,11 +25,18 @@ spec:
       containers:
       - image: 405906814034.dkr.ecr.ap-northeast-2.amazonaws.com/snutt-dev/snutt-timetable:98
         name: snutt-timetable
+        resources:
+          requests:
+            cpu: 100m
+            memory: 512Mi
+          limits:
+            cpu: 100m
+            memory: 512Mi
         ports:
         - containerPort: 8080
         env:
         - name: JAVA_OPTS
-          value: "-Duser.timezone=UTC"
+          value: "-XX:InitialRAMPercentage=80.0 -XX:MaxRAMPercentage=80.0 -Duser.timezone=UTC"
         - name: SPRING_PROFILES_ACTIVE
           value: "dev"
         - name: TRUFFLE_ENABLED

--- a/apps/snutt-prod/snutt-core/snutt-core.yaml
+++ b/apps/snutt-prod/snutt-core/snutt-core.yaml
@@ -25,6 +25,13 @@ spec:
       containers:
       - image: 405906814034.dkr.ecr.ap-northeast-2.amazonaws.com/snutt-prod/snutt-core:74
         name: snutt-core
+        resources:
+          requests:
+            cpu: 200m
+            memory: 256Mi
+          limits:
+            cpu: 200m
+            memory: 256Mi
         ports:
         - containerPort: 3000
 ---

--- a/apps/snutt-prod/snutt-ev-batch/snutt-ev-batch.yaml
+++ b/apps/snutt-prod/snutt-ev-batch/snutt-ev-batch.yaml
@@ -22,11 +22,18 @@ spec:
           containers:
           - image: 405906814034.dkr.ecr.ap-northeast-2.amazonaws.com/snutt-prod/snutt-ev-batch:2
             name: snutt-ev-batch-lecture-sync
+            resources:
+              requests:
+                cpu: 200m
+                memory: 1Gi
+              limits:
+                cpu: 1000m
+                memory: 1Gi
             env:
             - name: JOB_NAME
               value: "SYNC_JOB"
             - name: JAVA_OPTS
-              value: "-Duser.timezone=UTC"
+              value: "-XX:InitialRAMPercentage=80.0 -XX:MaxRAMPercentage=80.0 -Duser.timezone=UTC"
             - name: SPRING_PROFILES_ACTIVE
               value: "prod"
             - name: TRUFFLE_ENABLED
@@ -59,11 +66,18 @@ spec:
           containers:
           - image: 405906814034.dkr.ecr.ap-northeast-2.amazonaws.com/snutt-prod/snutt-ev-batch:2
             name: snutt-ev-batch-snuev-migration
+            resources:
+              requests:
+                cpu: 200m
+                memory: 1Gi
+              limits:
+                cpu: 1000m
+                memory: 1Gi
             env:
             - name: JOB_NAME
               value: "SNUEV_MIGRATION_JOB"
             - name: JAVA_OPTS
-              value: "-Duser.timezone=UTC"
+              value: "-XX:InitialRAMPercentage=80.0 -XX:MaxRAMPercentage=80.0 -Duser.timezone=UTC"
             - name: SPRING_PROFILES_ACTIVE
               value: "prod"
             - name: TRUFFLE_ENABLED

--- a/apps/snutt-prod/snutt-ev-web/snutt-ev-web.yaml
+++ b/apps/snutt-prod/snutt-ev-web/snutt-ev-web.yaml
@@ -24,6 +24,13 @@ spec:
       containers:
       - image: 405906814034.dkr.ecr.ap-northeast-2.amazonaws.com/snutt-prod/snutt-ev-web:101
         name: snutt-ev-web
+        resources:
+          requests:
+            cpu: 200m
+            memory: 256Mi
+          limits:
+            cpu: 200m
+            memory: 256Mi
         ports:
         - containerPort: 3000
 ---

--- a/apps/snutt-prod/snutt-ev/snutt-ev.yaml
+++ b/apps/snutt-prod/snutt-ev/snutt-ev.yaml
@@ -25,11 +25,18 @@ spec:
       containers:
       - image: 405906814034.dkr.ecr.ap-northeast-2.amazonaws.com/snutt-prod/snutt-ev:2
         name: snutt-ev
+        resources:
+          requests:
+            cpu: 200m
+            memory: 768Mi
+          limits:
+            cpu: 200m
+            memory: 768Mi
         ports:
         - containerPort: 8080
         env:
         - name: JAVA_OPTS
-          value: "-Duser.timezone=UTC"
+          value: "-XX:InitialRAMPercentage=80.0 -XX:MaxRAMPercentage=80.0 -Duser.timezone=UTC"
         - name: SPRING_PROFILES_ACTIVE
           value: "prod"
         - name: TRUFFLE_ENABLED

--- a/apps/snutt-prod/snutt-timetable-batch/snutt-timetable-batch.yaml
+++ b/apps/snutt-prod/snutt-timetable-batch/snutt-timetable-batch.yaml
@@ -22,11 +22,18 @@ spec:
           containers:
           - image: 405906814034.dkr.ecr.ap-northeast-2.amazonaws.com/snutt-prod/snutt-timetable-batch:17
             name: snutt-timetable-batch-coursebook
+            resources:
+              requests:
+                cpu: 200m
+                memory: 1Gi
+              limits:
+                cpu: 1000m
+                memory: 1Gi
             env:
             - name: JOB_NAME
               value: "sugangSnuMigrationJob"
             - name: JAVA_OPTS
-              value: "-Duser.timezone=UTC"
+              value: "-XX:InitialRAMPercentage=80.0 -XX:MaxRAMPercentage=80.0 -Duser.timezone=UTC"
             - name: SPRING_PROFILES_ACTIVE
               value: "prod"
             - name: TRUFFLE_ENABLED

--- a/apps/snutt-prod/snutt-timetable/snutt-timetable.yaml
+++ b/apps/snutt-prod/snutt-timetable/snutt-timetable.yaml
@@ -25,11 +25,18 @@ spec:
       containers:
       - image: 405906814034.dkr.ecr.ap-northeast-2.amazonaws.com/snutt-prod/snutt-timetable:17
         name: snutt-timetable
+        resources:
+          requests:
+            cpu: 200m
+            memory: 768Mi
+          limits:
+            cpu: 200m
+            memory: 768Mi
         ports:
         - containerPort: 8080
         env:
         - name: JAVA_OPTS
-          value: "-Duser.timezone=UTC"
+          value: "-XX:InitialRAMPercentage=80.0 -XX:MaxRAMPercentage=80.0 -Duser.timezone=UTC"
         - name: SPRING_PROFILES_ACTIVE
           value: "prod"
         - name: TRUFFLE_ENABLED

--- a/charts/istio/values.yaml
+++ b/charts/istio/values.yaml
@@ -1,0 +1,7 @@
+istiod:
+  global:
+    proxy:
+      resources:
+        limits:
+          cpu: 100m
+          memory: 128Mi


### PR DESCRIPTION
이 PR 이 merge 되면 나머지 wafflestudio 모든 pod template 에 대해서도 resources requests/limits 설정 예정

grafana.wafflestudio.com 를 보면서 적당히 잡아봄. 의견 주시면 좋습니다.

일단 우리가 쓰는 **각 node 는 t3.medium 으로 cpu 2000m, memory 4Gi** 입니다.

diff 봐도 알겠지만 정리해보자면

- **batch 를 제외한** 것들은 모두 `QoS` (Quality of Service) 를 안정적인 `Guranteed`가 되기 위해 **cpu, memory 모두 requests = limits 로 함**
- **batch 를 제외한** 것들은 모두 **cpu 는 dev requests/limits 모두 100m**, **prod 는 requests/limits 모두 200m** 으로 설정.

memory 의 경우 application 언어를 고려했는데
- snutt-core, snutt-ev-web 같은 js 계열 -> **dev 에선 192Mi, prod 에선 256Mi**
- snutt-ev, snutt-timetable 같은 spring 계열 -> **dev 에선 512Mi, prod 에선 768Mi**
- **spring 계열은 서버든 batch 든**, 아무 jvm 옵션 안 주면 initial heap 은 1/64, max heap 은 1/4 라서, **heap 이 실행 중에 동적 추가 할당 되는 일 없도록 & 충분히 더 쓸 수 있도록** `-XX:InitialRAMPercentage=80.0 -XX:MaxRAMPercentage=80.0` 설정 넣음. 즉, container memory 대비 80% 가 heap 으로 쓰임.

- spring 계열은 batch 가 있는데 아무래도 cpu, memory 를 많이 쓰는 경우가 많아서, batch 돌 때 node autoscale 된다고 감안하고 좀 더 넣으려고 함. **cpu는 dev, prod 모두 requests 200m, limits 1000m** / `memory 는 dev 768Mi, prod 1Gi`

* * *

istio-proxy container 의 경우, 기본 설정이 requests cpu 100m, memory 128Mi 이고 limits cpu 2000m, memory 1024Mi 인데 limits 가 과한 감이 있고, pod 의 모든 container 가 requests = limits 이어야 QoS `Guranteed`가 되어서 그냥 맞춰보려고 requests 랑 동일하게 설정해봄.