### PR TITLE
Increase snutt-ev-web memory

### DIFF
--- a/apps/snutt-prod/snutt-ev-web/snutt-ev-web.yaml
+++ b/apps/snutt-prod/snutt-ev-web/snutt-ev-web.yaml
@@ -27,10 +27,10 @@ spec:
         resources:
           requests:
             cpu: 200m
-            memory: 256Mi
+            memory: 384Mi
           limits:
             cpu: 200m
-            memory: 256Mi
+            memory: 384Mi
         ports:
         - containerPort: 3000
 ---


### PR DESCRIPTION
<img width="1666" alt="스크린샷 2023-07-03 12 09 02" src="https://github.com/wafflestudio/waffle-world/assets/35535636/72b4e991-7a8e-4808-a43e-6d6a7b99e98e">

snutt-ev-web 이 트래픽 많을 때 좀 이슈가 있는 거 같아서 (직접적으로 메모리 이슈인지 확신 X), 약간 빠듯하긴 한 듯해 올림