### PR TITLE
Set HPA for Snutt Services

### DIFF
--- a/apps/snutt-prod/snutt-core/snutt-core.yaml
+++ b/apps/snutt-prod/snutt-core/snutt-core.yaml
@@ -6,7 +6,7 @@ metadata:
     app: snutt-core
   namespace: snutt-prod
 spec:
-  replicas: 2
+  # replicas: HPA
   selector:
     matchLabels:
       app: snutt-core
@@ -34,6 +34,25 @@ spec:
             memory: 256Mi
         ports:
         - containerPort: 3000
+---
+apiVersion: autoscaling/v2beta2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: snutt-core-hpa
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: snutt-core
+  minReplicas: 1
+  maxReplicas: 3
+  metrics:
+  - type: Resource
+    resource:
+      name: cpu
+      target:
+        type: Utilization
+        averageUtilization: 80
 ---
 apiVersion: v1
 kind: ServiceAccount

--- a/apps/snutt-prod/snutt-ev-web/snutt-ev-web.yaml
+++ b/apps/snutt-prod/snutt-ev-web/snutt-ev-web.yaml
@@ -6,7 +6,7 @@ metadata:
     app: snutt-ev-web
   namespace: snutt-prod
 spec:
-  replicas: 2
+  # replicas: HPA
   selector:
     matchLabels:
       app: snutt-ev-web
@@ -33,6 +33,25 @@ spec:
             memory: 384Mi
         ports:
         - containerPort: 3000
+---
+apiVersion: autoscaling/v2beta2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: snutt-ev-web-hpa
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: snutt-ev-web
+  minReplicas: 1
+  maxReplicas: 3
+  metrics:
+  - type: Resource
+    resource:
+      name: cpu
+      target:
+        type: Utilization
+        averageUtilization: 80
 ---
 apiVersion: v1
 kind: Service

--- a/apps/snutt-prod/snutt-ev/snutt-ev.yaml
+++ b/apps/snutt-prod/snutt-ev/snutt-ev.yaml
@@ -6,7 +6,7 @@ metadata:
     app: snutt-ev
   namespace: snutt-prod
 spec:
-  replicas: 2
+  # replicas: HPA
   selector:
     matchLabels:
       app: snutt-ev
@@ -41,6 +41,25 @@ spec:
           value: "prod"
         - name: TRUFFLE_ENABLED
           value: "true"
+---
+apiVersion: autoscaling/v2beta2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: snutt-ev-hpa
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: snutt-ev
+  minReplicas: 1
+  maxReplicas: 3
+  metrics:
+  - type: Resource
+    resource:
+      name: cpu
+      target:
+        type: Utilization
+        averageUtilization: 80
 ---
 apiVersion: v1
 kind: ServiceAccount

--- a/apps/snutt-prod/snutt-timetable/snutt-timetable.yaml
+++ b/apps/snutt-prod/snutt-timetable/snutt-timetable.yaml
@@ -6,7 +6,7 @@ metadata:
     app: snutt-timetable
   namespace: snutt-prod
 spec:
-  replicas: 1
+  # replicas: HPA
   selector:
     matchLabels:
       app: snutt-timetable

--- a/apps/snutt-prod/snutt-timetable/snutt-timetable.yaml
+++ b/apps/snutt-prod/snutt-timetable/snutt-timetable.yaml
@@ -42,6 +42,25 @@ spec:
         - name: TRUFFLE_ENABLED
           value: "true"
 ---
+apiVersion: autoscaling/v2beta2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: snutt-timetable-hpa
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: snutt-timetable
+  minReplicas: 1
+  maxReplicas: 3
+  metrics:
+  - type: Resource
+    resource:
+      name: cpu
+      target:
+        type: Utilization
+        averageUtilization: 80
+---
 apiVersion: v1
 kind: ServiceAccount
 metadata:


### PR DESCRIPTION
수강편람 최초 등록 시 푸시 받고 많은 유저가 진입해서 7월 3일(월)에 장애 발생했었음. 급한대로 수동으로 일부 서비스 replicas 를 2로 늘려서 대응했으나, 자동으로 빠르게 대응하고자 함.

<img width="1460" alt="스크린샷 2023-07-05 19 20 15" src="https://github.com/wafflestudio/waffle-world/assets/35535636/7f794a54-7dd3-47b9-9037-1ff1bf58db2a">

HPA 쓰는 경우 ArgoCD 가 replicas 갖고 auto sync 하면 안 되니까 주석 처리
https://argo-cd.readthedocs.io/en/stable/user-guide/best_practices/#leaving-room-for-imperativeness

이 설정대로라면 cpu requests 의 80% 평균을 맞추도록 scaling 함