### PR TITLE
Set probes for snutt services

### DIFF
--- a/apps/snutt-dev/snutt-core/snutt-core.yaml
+++ b/apps/snutt-dev/snutt-core/snutt-core.yaml
@@ -34,6 +34,14 @@ spec:
             memory: 192Mi
         ports:
         - containerPort: 3000
+        livenessProbe:
+          httpGet:
+            path: /health-check
+            port: 3000
+        readinessProbe:
+          httpGet:
+            path: /health-check
+            port: 3000
 ---
 apiVersion: v1
 kind: ServiceAccount

--- a/apps/snutt-dev/snutt-ev-web/snutt-ev-web.yaml
+++ b/apps/snutt-dev/snutt-ev-web/snutt-ev-web.yaml
@@ -33,6 +33,14 @@ spec:
             memory: 256Mi
         ports:
         - containerPort: 3000
+        livenessProbe:
+          httpGet:
+            path: /api/health-check
+            port: 3000
+        readinessProbe:
+          httpGet:
+            path: /api/health-check
+            port: 3000
 ---
 apiVersion: v1
 kind: Service

--- a/apps/snutt-dev/snutt-ev/snutt-ev.yaml
+++ b/apps/snutt-dev/snutt-ev/snutt-ev.yaml
@@ -34,6 +34,14 @@ spec:
             memory: 512Mi
         ports:
         - containerPort: 8080
+        livenessProbe:
+          httpGet:
+            path: /health-check
+            port: 8080
+        readinessProbe:
+          httpGet:
+            path: /health-check
+            port: 8080
         env:
         - name: JAVA_OPTS
           value: "-XX:InitialRAMPercentage=80.0 -XX:MaxRAMPercentage=80.0 -Duser.timezone=UTC"

--- a/apps/snutt-dev/snutt-timetable/snutt-timetable.yaml
+++ b/apps/snutt-dev/snutt-timetable/snutt-timetable.yaml
@@ -34,6 +34,14 @@ spec:
             memory: 512Mi
         ports:
         - containerPort: 8080
+        livenessProbe:
+          httpGet:
+            path: /health-check
+            port: 8080
+        readinessProbe:
+          httpGet:
+            path: /health-check
+            port: 8080
         env:
         - name: JAVA_OPTS
           value: "-XX:InitialRAMPercentage=80.0 -XX:MaxRAMPercentage=80.0 -Duser.timezone=UTC"

--- a/apps/snutt-prod/snutt-core/snutt-core.yaml
+++ b/apps/snutt-prod/snutt-core/snutt-core.yaml
@@ -34,6 +34,14 @@ spec:
             memory: 256Mi
         ports:
         - containerPort: 3000
+        livenessProbe:
+          httpGet:
+            path: /health-check
+            port: 3000
+        readinessProbe:
+          httpGet:
+            path: /health-check
+            port: 3000
 ---
 apiVersion: v1
 kind: ServiceAccount

--- a/apps/snutt-prod/snutt-ev-web/snutt-ev-web.yaml
+++ b/apps/snutt-prod/snutt-ev-web/snutt-ev-web.yaml
@@ -33,6 +33,14 @@ spec:
             memory: 384Mi
         ports:
         - containerPort: 3000
+        livenessProbe:
+          httpGet:
+            path: /api/health-check
+            port: 3000
+        readinessProbe:
+          httpGet:
+            path: /api/health-check
+            port: 3000
 ---
 apiVersion: v1
 kind: Service

--- a/apps/snutt-prod/snutt-ev/snutt-ev.yaml
+++ b/apps/snutt-prod/snutt-ev/snutt-ev.yaml
@@ -34,6 +34,14 @@ spec:
             memory: 768Mi
         ports:
         - containerPort: 8080
+        livenessProbe:
+          httpGet:
+            path: /health-check
+            port: 8080
+        readinessProbe:
+          httpGet:
+            path: /health-check
+            port: 8080
         env:
         - name: JAVA_OPTS
           value: "-XX:InitialRAMPercentage=80.0 -XX:MaxRAMPercentage=80.0 -Duser.timezone=UTC"

--- a/apps/snutt-prod/snutt-timetable/snutt-timetable.yaml
+++ b/apps/snutt-prod/snutt-timetable/snutt-timetable.yaml
@@ -34,6 +34,14 @@ spec:
             memory: 768Mi
         ports:
         - containerPort: 8080
+        livenessProbe:
+          httpGet:
+            path: /health-check
+            port: 8080
+        readinessProbe:
+          httpGet:
+            path: /health-check
+            port: 8080
         env:
         - name: JAVA_OPTS
           value: "-XX:InitialRAMPercentage=80.0 -XX:MaxRAMPercentage=80.0 -Duser.timezone=UTC"


### PR DESCRIPTION
snutt-ev-web 이 socket 끊어져서 아무 요청 못 받고 있는데, pod 재시작도 안 되고 있던 문제가 있었습니다.

https://wafflestudio.slack.com/archives/C0PAVPS5T/p1688382668501989

이에 각 application 에 health-check endpoint 추가하고 liveness, readiness probe 설정합니다. 일단 initialDelaySeconds 는 따로 주지 않았습니다.

