### PR TITLE
Routes more apis to snu4t

### DIFF
--- a/apps/snutt-dev/snutt-core/snutt-core.yaml
+++ b/apps/snutt-dev/snutt-core/snutt-core.yaml
@@ -81,9 +81,7 @@ spec:
         regex: ^(?:\/v1)?\/auth\/login_local\/?$
     - uri:
         regex: ^(?:\/v1)?\/auth\/logout\/?$
-    - method:
-        exact: POST
-      uri:
+    - uri:
         regex: ^(?:\/v1)?\/search_query\/?$
     - uri:
         regex: ^(?:\/v1)?\/user\/device(\/.*)?$

--- a/apps/snutt-dev/snutt-core/snutt-core.yaml
+++ b/apps/snutt-dev/snutt-core/snutt-core.yaml
@@ -79,21 +79,23 @@ spec:
         regex: ^(?:\/v1)?\/auth\/register_local\/?$
     - uri:
         regex: ^(?:\/v1)?\/auth\/login_local\/?$
+    - uri:
+        regex: ^(?:\/v1)?\/auth\/logout\/?$
     - method:
         exact: POST
       uri:
         regex: ^(?:\/v1)?\/search_query\/?$
-    - method:
-        exact: GET
-      uri:
-        regex: ^(?:\/v1)?\/notification\/?$
+    - uri:
+        regex: ^(?:\/v1)?\/user\/device(\/.*)?$
+    - uri:
+        regex: ^(?:\/v1)?\/notification(\/.*)?$
+    - uri:
+        regex: ^(?:\/v1)?\/admin/insert_noti\/?$
     ################# new apis ##############
-    - method:
-        exact: GET
-      uri:
-        regex: ^\/v1\/tables\/(\w{24})\/links$
     - uri:
         regex: ^\/v1\/bookmarks(\/.*)?$
+    - uri:
+        regex: ^\/v1\/tables\/(\w{24})\/links$
     - uri:
         regex: ^\/v1\/shared-tables(\/.*)?$
     route:

--- a/apps/snutt-prod/snutt-core/snutt-core.yaml
+++ b/apps/snutt-prod/snutt-core/snutt-core.yaml
@@ -81,9 +81,7 @@ spec:
         regex: ^(?:\/v1)?\/auth\/login_local\/?$
     - uri:
         regex: ^(?:\/v1)?\/auth\/logout\/?$
-    - method:
-        exact: POST
-      uri:
+    - uri:
         regex: ^(?:\/v1)?\/search_query\/?$
     - uri:
         regex: ^(?:\/v1)?\/user\/device(\/.*)?$

--- a/apps/snutt-prod/snutt-core/snutt-core.yaml
+++ b/apps/snutt-prod/snutt-core/snutt-core.yaml
@@ -70,6 +70,7 @@ spec:
   - name: "prod-snutt-timetable-route"
     timeout: 10s
     match:
+    ############## migrated apis ############
     - method:
         exact: GET
       uri:
@@ -78,10 +79,19 @@ spec:
         regex: ^(?:\/v1)?\/auth\/register_local\/?$
     - uri:
         regex: ^(?:\/v1)?\/auth\/login_local\/?$
+    - uri:
+        regex: ^(?:\/v1)?\/auth\/logout\/?$
     - method:
         exact: POST
       uri:
         regex: ^(?:\/v1)?\/search_query\/?$
+    - uri:
+        regex: ^(?:\/v1)?\/user\/device(\/.*)?$
+    - uri:
+        regex: ^(?:\/v1)?\/notification(\/.*)?$
+    - uri:
+        regex: ^(?:\/v1)?\/admin/insert_noti\/?$
+    ################# new apis ##############
     - uri:
         regex: ^\/v1\/bookmarks(\/.*)?$
     route:


### PR DESCRIPTION
snu4t 추가 migration 개발 진행에 따라, logout API, device APIs, notification APIs 를 dev, prod 에서 routing 변경
굳이 method 명시 안 해도 되는 경우 제거. 순서 일관성 있게 변경.