### PR TITLE
bind batch resource rule to truffle

### DIFF
--- a/apps/truffle-prod/truffle-consumer/service-account.yaml
+++ b/apps/truffle-prod/truffle-consumer/service-account.yaml
@@ -5,3 +5,29 @@ metadata:
   namespace: truffle-prod
   annotations:
     eks.amazonaws.com/role-arn: arn:aws:iam::405906814034:role/truffle-prod-role
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: truffle
+rules:
+  - apiGroups:
+      - "batch"
+    resources:
+      - jobs
+      - cronjobs
+    verbs:
+      - "*"
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: truffle
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: truffle
+subjects:
+  - kind: ServiceAccount
+    name: truffle
+    namespace: truffle-prod


### PR DESCRIPTION
[크론잡 실패 케이스](https://wafflestudio.slack.com/archives/C01M4TMNFPX/p1688703115629899)

요거 보고 나서 생각난건데, 

와플 클러스터 배치 상태를 모니터링해서 알람 해주는 거 추가하려고 해요.

+ 트러플 컨슈머에 들어가는게 맞나 싶긴한데,, 우리 리소스가 후달리니까 일단 여기서 하려고 합니다. 이거는 의견주셔도 좋습니다.