### PR TITLE
timeoutSeconds for probes

### DIFF
--- a/apps/snutt-dev/snutt-ev-web/snutt-ev-web.yaml
+++ b/apps/snutt-dev/snutt-ev-web/snutt-ev-web.yaml
@@ -37,10 +37,12 @@ spec:
           httpGet:
             path: /api/health-check
             port: 3000
+          timeoutSeconds: 3
         readinessProbe:
           httpGet:
             path: /api/health-check
             port: 3000
+          timeoutSeconds: 3
 ---
 apiVersion: v1
 kind: Service

--- a/apps/snutt-dev/snutt-ev/snutt-ev.yaml
+++ b/apps/snutt-dev/snutt-ev/snutt-ev.yaml
@@ -38,10 +38,12 @@ spec:
           httpGet:
             path: /health-check
             port: 8080
+          timeoutSeconds: 3
         readinessProbe:
           httpGet:
             path: /health-check
             port: 8080
+          timeoutSeconds: 3
         env:
         - name: JAVA_OPTS
           value: "-XX:InitialRAMPercentage=80.0 -XX:MaxRAMPercentage=80.0 -Duser.timezone=UTC"

--- a/apps/snutt-dev/snutt-timetable/snutt-timetable.yaml
+++ b/apps/snutt-dev/snutt-timetable/snutt-timetable.yaml
@@ -38,10 +38,12 @@ spec:
           httpGet:
             path: /health-check
             port: 8080
+          timeoutSeconds: 3
         readinessProbe:
           httpGet:
             path: /health-check
             port: 8080
+          timeoutSeconds: 3
         env:
         - name: JAVA_OPTS
           value: "-XX:InitialRAMPercentage=80.0 -XX:MaxRAMPercentage=80.0 -Duser.timezone=UTC"

--- a/apps/snutt-prod/snutt-ev-web/snutt-ev-web.yaml
+++ b/apps/snutt-prod/snutt-ev-web/snutt-ev-web.yaml
@@ -37,10 +37,12 @@ spec:
           httpGet:
             path: /api/health-check
             port: 3000
+          timeoutSeconds: 3
         readinessProbe:
           httpGet:
             path: /api/health-check
             port: 3000
+          timeoutSeconds: 3
 ---
 apiVersion: autoscaling/v2beta2
 kind: HorizontalPodAutoscaler

--- a/apps/snutt-prod/snutt-ev/snutt-ev.yaml
+++ b/apps/snutt-prod/snutt-ev/snutt-ev.yaml
@@ -38,10 +38,12 @@ spec:
           httpGet:
             path: /health-check
             port: 8080
+          timeoutSeconds: 3
         readinessProbe:
           httpGet:
             path: /health-check
             port: 8080
+          timeoutSeconds: 3
         env:
         - name: JAVA_OPTS
           value: "-XX:InitialRAMPercentage=80.0 -XX:MaxRAMPercentage=80.0 -Duser.timezone=UTC"

--- a/apps/snutt-prod/snutt-timetable/snutt-timetable.yaml
+++ b/apps/snutt-prod/snutt-timetable/snutt-timetable.yaml
@@ -38,10 +38,12 @@ spec:
           httpGet:
             path: /health-check
             port: 8080
+          timeoutSeconds: 3
         readinessProbe:
           httpGet:
             path: /health-check
             port: 8080
+          timeoutSeconds: 3
         env:
         - name: JAVA_OPTS
           value: "-XX:InitialRAMPercentage=80.0 -XX:MaxRAMPercentage=80.0 -Duser.timezone=UTC"


### PR DESCRIPTION
probes 들이 자꾸 500 나서 앱 뜨자마자 `timeoutSeconds: 1`이 짧나 싶어서 증가
