### PR TITLE
set startupProbe for Snutt Services

### DIFF
--- a/apps/snutt-dev/snutt-ev-web/snutt-ev-web.yaml
+++ b/apps/snutt-dev/snutt-ev-web/snutt-ev-web.yaml
@@ -44,7 +44,7 @@ spec:
         startupProbe:
           httpGet:
             path: /health-check
-            port: 8080
+            port: 3000
           failureThreshold: 5
 ---
 apiVersion: v1

--- a/apps/snutt-dev/snutt-ev-web/snutt-ev-web.yaml
+++ b/apps/snutt-dev/snutt-ev-web/snutt-ev-web.yaml
@@ -37,12 +37,15 @@ spec:
           httpGet:
             path: /api/health-check
             port: 3000
-          timeoutSeconds: 3
         readinessProbe:
           httpGet:
             path: /api/health-check
             port: 3000
-          timeoutSeconds: 3
+        startupProbe:
+          httpGet:
+            path: /health-check
+            port: 8080
+          failureThreshold: 5
 ---
 apiVersion: v1
 kind: Service

--- a/apps/snutt-dev/snutt-ev/snutt-ev.yaml
+++ b/apps/snutt-dev/snutt-ev/snutt-ev.yaml
@@ -38,12 +38,15 @@ spec:
           httpGet:
             path: /health-check
             port: 8080
-          timeoutSeconds: 3
         readinessProbe:
           httpGet:
             path: /health-check
             port: 8080
-          timeoutSeconds: 3
+        startupProbe:
+          httpGet:
+            path: /health-check
+            port: 8080
+          failureThreshold: 5
         env:
         - name: JAVA_OPTS
           value: "-XX:InitialRAMPercentage=80.0 -XX:MaxRAMPercentage=80.0 -Duser.timezone=UTC"

--- a/apps/snutt-dev/snutt-timetable/snutt-timetable.yaml
+++ b/apps/snutt-dev/snutt-timetable/snutt-timetable.yaml
@@ -38,12 +38,15 @@ spec:
           httpGet:
             path: /health-check
             port: 8080
-          timeoutSeconds: 3
         readinessProbe:
           httpGet:
             path: /health-check
             port: 8080
-          timeoutSeconds: 3
+        startupProbe:
+          httpGet:
+            path: /health-check
+            port: 8080
+          failureThreshold: 5
         env:
         - name: JAVA_OPTS
           value: "-XX:InitialRAMPercentage=80.0 -XX:MaxRAMPercentage=80.0 -Duser.timezone=UTC"

--- a/apps/snutt-prod/snutt-ev-web/snutt-ev-web.yaml
+++ b/apps/snutt-prod/snutt-ev-web/snutt-ev-web.yaml
@@ -37,12 +37,15 @@ spec:
           httpGet:
             path: /api/health-check
             port: 3000
-          timeoutSeconds: 3
         readinessProbe:
           httpGet:
             path: /api/health-check
             port: 3000
-          timeoutSeconds: 3
+        startupProbe:
+          httpGet:
+            path: /health-check
+            port: 8080
+          failureThreshold: 5
 ---
 apiVersion: autoscaling/v2beta2
 kind: HorizontalPodAutoscaler

--- a/apps/snutt-prod/snutt-ev-web/snutt-ev-web.yaml
+++ b/apps/snutt-prod/snutt-ev-web/snutt-ev-web.yaml
@@ -44,7 +44,7 @@ spec:
         startupProbe:
           httpGet:
             path: /health-check
-            port: 8080
+            port: 3000
           failureThreshold: 5
 ---
 apiVersion: autoscaling/v2beta2

--- a/apps/snutt-prod/snutt-ev/snutt-ev.yaml
+++ b/apps/snutt-prod/snutt-ev/snutt-ev.yaml
@@ -38,12 +38,15 @@ spec:
           httpGet:
             path: /health-check
             port: 8080
-          timeoutSeconds: 3
         readinessProbe:
           httpGet:
             path: /health-check
             port: 8080
-          timeoutSeconds: 3
+        startupProbe:
+          httpGet:
+            path: /health-check
+            port: 8080
+          failureThreshold: 5
         env:
         - name: JAVA_OPTS
           value: "-XX:InitialRAMPercentage=80.0 -XX:MaxRAMPercentage=80.0 -Duser.timezone=UTC"

--- a/apps/snutt-prod/snutt-timetable/snutt-timetable.yaml
+++ b/apps/snutt-prod/snutt-timetable/snutt-timetable.yaml
@@ -38,12 +38,15 @@ spec:
           httpGet:
             path: /health-check
             port: 8080
-          timeoutSeconds: 3
         readinessProbe:
           httpGet:
             path: /health-check
             port: 8080
-          timeoutSeconds: 3
+        startupProbe:
+          httpGet:
+            path: /health-check
+            port: 8080
+          failureThreshold: 5
         env:
         - name: JAVA_OPTS
           value: "-XX:InitialRAMPercentage=80.0 -XX:MaxRAMPercentage=80.0 -Duser.timezone=UTC"


### PR DESCRIPTION
related #97, #93 

시작이 느릴 수 있는 application 들을 위해, startupProbe 설정. container 를 실패로 간주하고 너무 빠르게 재시작하는 것 방지.