### PR TITLE
Upgrade argocd chart & Schedule to prod nodegroup

### DIFF
--- a/charts/argocd/Chart.lock
+++ b/charts/argocd/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: argo-cd
   repository: https://argoproj.github.io/argo-helm
-  version: 5.5.12
-digest: sha256:44c96461c40f62ff8941dce744a5a3cbceeef0c36998cc15e574f16a8e558783
-generated: "2022-10-15T03:01:11.769043+09:00"
+  version: 5.39.0
+digest: sha256:517d32206c3abca78dc7e8c12e686a987e80da58f4c1f654f4fe3b1749f4d1d1
+generated: "2023-07-15T04:08:23.122424+09:00"

--- a/charts/argocd/Chart.yaml
+++ b/charts/argocd/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: argocd
-version: 1.1.0
+version: 1.2.0
 dependencies:
 - name: argo-cd
-  version: 5.5.12
+  version: 5.39.0
   repository: https://argoproj.github.io/argo-helm

--- a/charts/argocd/values.yaml
+++ b/charts/argocd/values.yaml
@@ -69,10 +69,10 @@ argo-cd:
     resources:
       requests:
         cpu: 10m
-        memory: 64Mi
+        memory: 128Mi
       limits:
         cpu: 50m
-        memory: 64Mi
+        memory: 128Mi
   dex:
     resources:
       requests:

--- a/charts/argocd/values.yaml
+++ b/charts/argocd/values.yaml
@@ -7,10 +7,8 @@ argo-cd:
         key: phase
         operator: Equal
         value: prod
-  server:
-    extraArgs:
-    - --insecure
-    config:
+  configs:
+    cm:
       url: https://argocd.wafflestudio.com
       timeout.reconciliation: 15s
       dex.config: |
@@ -24,7 +22,7 @@ argo-cd:
             orgs:
             - name: wafflestudio
       admin.enabled: "false"
-    rbacConfig:
+    rbac:
       policy.default: role:readonly
       policy.csv: |
         p, role:waffle-k8s-admin, applications, *, */*, allow
@@ -34,6 +32,9 @@ argo-cd:
         p, role:waffle-k8s-admin, repositories, update, *, allow
         p, role:waffle-k8s-admin, repositories, delete, *, allow
         g, wafflestudio:waffle-k8s-admin, role:waffle-k8s-admin
+    params:
+      server.insecure: true
+  server:
     resources:
       requests:
         cpu: 50m
@@ -77,10 +78,10 @@ argo-cd:
     resources:
       requests:
         cpu: 10m
-        memory: 32Mi
+        memory: 64Mi
       limits:
         cpu: 50m
-        memory: 32Mi
+        memory: 64Mi
   redis:
     resources:
       requests:

--- a/charts/argocd/values.yaml
+++ b/charts/argocd/values.yaml
@@ -1,4 +1,12 @@
 argo-cd:
+  global:
+    nodeSelector:
+      phase: prod
+    tolerations:
+      - effect: NoSchedule
+        key: phase
+        operator: Equal
+        value: prod
   server:
     extraArgs:
     - --insecure

--- a/charts/argocd/values.yaml
+++ b/charts/argocd/values.yaml
@@ -34,3 +34,59 @@ argo-cd:
         p, role:waffle-k8s-admin, repositories, update, *, allow
         p, role:waffle-k8s-admin, repositories, delete, *, allow
         g, wafflestudio:waffle-k8s-admin, role:waffle-k8s-admin
+    resources:
+      requests:
+        cpu: 50m
+        memory: 64Mi
+      limits:
+        cpu: 100m
+        memory: 64Mi
+  controller:
+    resources:
+      requests:
+        cpu: 250m
+        memory: 256Mi
+      limits:
+        cpu: 500m
+        memory: 256Mi
+  applicationSet:
+    resources:
+      requests:
+        cpu: 50m
+        memory: 64Mi
+      limits:
+        cpu: 100m
+        memory: 64Mi
+  notifications:
+    resources:
+      requests:
+        cpu: 50m
+        memory: 64Mi
+      limits:
+        cpu: 100m
+        memory: 64Mi
+  repoServer:
+    resources:
+      requests:
+        cpu: 10m
+        memory: 64Mi
+      limits:
+        cpu: 50m
+        memory: 64Mi
+  dex:
+    resources:
+      requests:
+        cpu: 10m
+        memory: 32Mi
+      limits:
+        cpu: 50m
+        memory: 32Mi
+  redis:
+    resources:
+      requests:
+        cpu: 100m
+        memory: 64Mi
+      limits:
+        cpu: 200m
+        memory: 64Mi
+


### PR DESCRIPTION
의존하는 argocd chart 버전 올림
prod nodegroup 에 할당되도록 함

덕분에 디자인도 바뀌었습니다 ㅋㅋ

<img width="1701" alt="스크린샷 2023-07-15 04 17 16" src="https://github.com/wafflestudio/waffle-world/assets/35535636/7dee3480-6420-431a-a3aa-e022780861e4">
