### PR TITLE
Schedule feelin-prod to prod nodegroup & Set Resources & etc

### DIFF
--- a/apps/feelin-dev/feelin-core-server/feelin-core-server.yaml
+++ b/apps/feelin-dev/feelin-core-server/feelin-core-server.yaml
@@ -48,6 +48,7 @@ metadata:
 spec:
   gateways:
   - istio-ingress/waffle-ingressgateway
+  - mesh
   hosts:
   - feelin-api-dev.wafflestudio.com
   http:

--- a/apps/feelin-dev/feelin-core-server/feelin-core-server.yaml
+++ b/apps/feelin-dev/feelin-core-server/feelin-core-server.yaml
@@ -6,7 +6,7 @@ metadata:
     app: feelin-core-server
   namespace: feelin-dev
 spec:
-  replicas: 1
+  replicas: 0
   selector:
     matchLabels:
       app: feelin-core-server
@@ -24,6 +24,13 @@ spec:
       containers:
       - image: 405906814034.dkr.ecr.ap-northeast-2.amazonaws.com/feelin-dev/feelin-core-server:48
         name: feelin-core-server
+        resources:
+          requests:
+            cpu: 100m
+            memory: 192Mi
+          limits:
+            cpu: 100m
+            memory: 192Mi
         ports:
         - containerPort: 3000
 ---

--- a/apps/feelin-dev/feelin-social-server/feelin-social-server.yaml
+++ b/apps/feelin-dev/feelin-social-server/feelin-social-server.yaml
@@ -48,6 +48,7 @@ metadata:
 spec:
   gateways:
     - istio-ingress/waffle-ingressgateway
+    - mesh
   hosts:
     - feelin-social-api-dev.wafflestudio.com
   http:

--- a/apps/feelin-dev/feelin-social-server/feelin-social-server.yaml
+++ b/apps/feelin-dev/feelin-social-server/feelin-social-server.yaml
@@ -6,7 +6,7 @@ metadata:
     app: feelin-social-server
   namespace: feelin-dev
 spec:
-  replicas: 1
+  replicas: 0
   selector:
     matchLabels:
       app: feelin-social-server
@@ -22,10 +22,20 @@ spec:
         app: feelin-social-server
     spec:
       containers:
-        - image: 405906814034.dkr.ecr.ap-northeast-2.amazonaws.com/feelin-dev/feelin-social-server:29
-          name: feelin-social-server
-          ports:
-            - containerPort: 8080
+      - image: 405906814034.dkr.ecr.ap-northeast-2.amazonaws.com/feelin-dev/feelin-social-server:29
+        name: feelin-social-server
+        resources:
+          requests:
+            cpu: 100m
+            memory: 256Mi
+          limits:
+            cpu: 200m
+            memory: 256Mi
+        ports:
+        - containerPort: 8080
+        env:
+        - name: JAVA_OPTS
+          value: "-XX:InitialRAMPercentage=80.0 -XX:MaxRAMPercentage=80.0"
 ---
 apiVersion: v1
 kind: Service

--- a/apps/feelin-dev/feelin-social-server/feelin-social-server.yaml
+++ b/apps/feelin-dev/feelin-social-server/feelin-social-server.yaml
@@ -22,7 +22,7 @@ spec:
         app: feelin-social-server
     spec:
       containers:
-      - image: 405906814034.dkr.ecr.ap-northeast-2.amazonaws.com/feelin-dev/feelin-social-server:29
+      - image: 405906814034.dkr.ecr.ap-northeast-2.amazonaws.com/feelin-dev/feelin-social-server:30
         name: feelin-social-server
         resources:
           requests:

--- a/apps/feelin-dev/feelin-web/feelin-web.yaml
+++ b/apps/feelin-dev/feelin-web/feelin-web.yaml
@@ -48,6 +48,7 @@ metadata:
 spec:
   gateways:
   - istio-ingress/waffle-ingressgateway
+  - mesh
   hosts:
   - feelin-dev.wafflestudio.com
   http:

--- a/apps/feelin-dev/feelin-web/feelin-web.yaml
+++ b/apps/feelin-dev/feelin-web/feelin-web.yaml
@@ -6,7 +6,7 @@ metadata:
     app: feelin-web
   namespace: feelin-dev
 spec:
-  replicas: 1
+  replicas: 0
   selector:
     matchLabels:
       app: feelin-web
@@ -24,6 +24,13 @@ spec:
       containers:
       - image: 405906814034.dkr.ecr.ap-northeast-2.amazonaws.com/feelin-dev/feelin-web:16
         name: feelin-web
+        resources:
+          requests:
+            cpu: 100m
+            memory: 128Mi
+          limits:
+            cpu: 100m
+            memory: 128Mi
         ports:
         - containerPort: 3000
 ---

--- a/apps/feelin-prod/feelin-core-server/feelin-core-server.yaml
+++ b/apps/feelin-prod/feelin-core-server/feelin-core-server.yaml
@@ -21,9 +21,23 @@ spec:
       labels:
         app: feelin-core-server
     spec:
+      nodeSelector:
+        phase: prod
+      tolerations:
+        - effect: NoSchedule
+          key: phase
+          operator: Equal
+          value: prod
       containers:
       - image: 405906814034.dkr.ecr.ap-northeast-2.amazonaws.com/feelin-prod/feelin-core-server:10
         name: feelin-core-server
+        resources:
+          requests:
+            cpu: 100m
+            memory: 192Mi
+          limits:
+            cpu: 100m
+            memory: 192Mi
         ports:
         - containerPort: 3000
 ---

--- a/apps/feelin-prod/feelin-social-server/feelin-social-server.yaml
+++ b/apps/feelin-prod/feelin-social-server/feelin-social-server.yaml
@@ -29,7 +29,7 @@ spec:
           operator: Equal
           value: prod
       containers:
-      - image: 405906814034.dkr.ecr.ap-northeast-2.amazonaws.com/feelin-prod/feelin-social-server:14
+      - image: 405906814034.dkr.ecr.ap-northeast-2.amazonaws.com/feelin-prod/feelin-social-server:15
         name: feelin-social-server
         resources:
           requests:

--- a/apps/feelin-prod/feelin-social-server/feelin-social-server.yaml
+++ b/apps/feelin-prod/feelin-social-server/feelin-social-server.yaml
@@ -21,11 +21,28 @@ spec:
       labels:
         app: feelin-social-server
     spec:
+      nodeSelector:
+        phase: prod
+      tolerations:
+        - effect: NoSchedule
+          key: phase
+          operator: Equal
+          value: prod
       containers:
-        - image: 405906814034.dkr.ecr.ap-northeast-2.amazonaws.com/feelin-prod/feelin-social-server:14
-          name: feelin-social-server
-          ports:
-            - containerPort: 8080
+      - image: 405906814034.dkr.ecr.ap-northeast-2.amazonaws.com/feelin-prod/feelin-social-server:14
+        name: feelin-social-server
+        resources:
+          requests:
+            cpu: 100m
+            memory: 256Mi
+          limits:
+            cpu: 200m
+            memory: 256Mi
+        ports:
+        - containerPort: 8080
+        env:
+        - name: JAVA_OPTS
+          value: "-XX:InitialRAMPercentage=80.0 -XX:MaxRAMPercentage=80.0"
 ---
 apiVersion: v1
 kind: Service

--- a/apps/feelin-prod/feelin-web/feelin-web.yaml
+++ b/apps/feelin-prod/feelin-web/feelin-web.yaml
@@ -21,9 +21,23 @@ spec:
       labels:
         app: feelin-web
     spec:
+      nodeSelector:
+        phase: prod
+      tolerations:
+        - effect: NoSchedule
+          key: phase
+          operator: Equal
+          value: prod
       containers:
       - image: 405906814034.dkr.ecr.ap-northeast-2.amazonaws.com/feelin-prod/feelin-web:19
         name: feelin-web
+        resources:
+          requests:
+            cpu: 100m
+            memory: 128Mi
+          limits:
+            cpu: 100m
+            memory: 128Mi
         ports:
         - containerPort: 3000
 ---

--- a/misc/argocd/virtualservice.yaml
+++ b/misc/argocd/virtualservice.yaml
@@ -8,6 +8,7 @@ spec:
   - istio-ingress/waffle-ingressgateway
   hosts:
   - argocd.wafflestudio.com
+  - mesh
   http:
   - route:
     - destination:

--- a/misc/grafana/virtualservice.yaml
+++ b/misc/grafana/virtualservice.yaml
@@ -8,6 +8,7 @@ spec:
   - istio-ingress/waffle-ingressgateway
   hosts:
   - grafana.wafflestudio.com
+  - mesh
   http:
   - route:
     - destination:


### PR DESCRIPTION
https://apps.apple.com/kr/app/feelin/id1665350212?l=en

- feelin-prod 는 유저가 사용하므로 prod nodegroup 에 배치
- feelin-dev 는 현재 개발 중단 상황이므로 replicas 0
- feelin 서버들 resources 설정 (JAVA_OPTS 관련해서는 wafflestudio/feelin-server#298 참고
- mesh 빠져있던 것들에 더 넣음

https://wafflestudio.slack.com/archives/C01M4TMNFPX/p1687075623044219