### PR TITLE
increase maximum value of memory of wacruit-dev-judge-server

### DIFF
--- a/apps/wacruit-dev/wacruit-judge/wacruit-judge-server.yaml
+++ b/apps/wacruit-dev/wacruit-judge/wacruit-judge-server.yaml
@@ -38,7 +38,7 @@ spec:
             memory: 192Mi
           limits:
             cpu: 200m
-            memory: 192Mi
+            memory: 256Mi
         ports:
           - containerPort: 2358
 ---


### PR DESCRIPTION
ruby on rails 가 기본으로 잡아먹는 메모리가 생각보다 많네요..
평소에 별 요청이 없을 때에도 상시로 200MiB에 언저리의 메모리를 점유하고 있는데 최대 메모리를 192MiB로 설정해둔 상태라 요청이 한두 건만 둘어와도 쉽게 터지는 상황입니다 ㅠ 50MiB 정도만 메모리 여유분을 추가해도 될까요??

<img width="1002" alt="image" src="https://github.com/wafflestudio/waffle-world/assets/71511067/962d09d0-4fb7-42fe-9429-95cd3d2899fb">
