### PR TITLE
argocd perm for waffledotcom, snutt

### DIFF
--- a/charts/argocd/values.yaml
+++ b/charts/argocd/values.yaml
@@ -33,10 +33,6 @@ argo-cd:
         p, role:waffle-k8s-admin, repositories, update, *, allow
         p, role:waffle-k8s-admin, repositories, delete, *, allow
 
-        g, wafflestudio:snutt-frontend, role:snutt-frontend
-        p, role:snutt-frontend, applications, *, default/snutt-ev-web, allow
-        p, role:snutt-frontend, applications, *, default/snutt-ev-web-dev, allow
-
         g, wafflestudio:snutt-server, role:snutt-server
         p, role:snutt-server, applications, *, default/snutt-core, allow
         p, role:snutt-server, applications, *, default/snutt-core-dev, allow
@@ -49,17 +45,9 @@ argo-cd:
         p, role:snutt-server, applications, *, default/snutt-timetable-batch, allow
         p, role:snutt-server, applications, *, default/snutt-timetable-batch-dev, allow
         
-        g, wafflestudio:snutt-server, role:snutt-server
-        p, role:snutt-server, applications, *, default/snutt-core, allow
-        p, role:snutt-server, applications, *, default/snutt-core-dev, allow
-        p, role:snutt-server, applications, *, default/snutt-ev, allow
-        p, role:snutt-server, applications, *, default/snutt-ev-dev, allow
-        p, role:snutt-server, applications, *, default/snutt-ev-batch, allow
-        p, role:snutt-server, applications, *, default/snutt-ev-batch-dev, allow
-        p, role:snutt-server, applications, *, default/snutt-timetable, allow
-        p, role:snutt-server, applications, *, default/snutt-timetable-dev, allow
-        p, role:snutt-server, applications, *, default/snutt-timetable-batch, allow
-        p, role:snutt-server, applications, *, default/snutt-timetable-batch-dev, allow
+        g, wafflestudio:snutt-frontend, role:snutt-frontend
+        p, role:snutt-frontend, applications, *, default/snutt-ev-web, allow
+        p, role:snutt-frontend, applications, *, default/snutt-ev-web-dev, allow
         
         g, wafflestudio:waffledotcom-backend, role:waffledotcom-backend
         p, role:waffledotcom-backend, applications, *, default/waffledotcom-server, allow

--- a/charts/argocd/values.yaml
+++ b/charts/argocd/values.yaml
@@ -25,13 +25,49 @@ argo-cd:
     rbac:
       policy.default: role:readonly
       policy.csv: |
+        g, wafflestudio:waffle-k8s-admin, role:waffle-k8s-admin
         p, role:waffle-k8s-admin, applications, *, */*, allow
         p, role:waffle-k8s-admin, clusters, get, *, allow
         p, role:waffle-k8s-admin, repositories, get, *, allow
         p, role:waffle-k8s-admin, repositories, create, *, allow
         p, role:waffle-k8s-admin, repositories, update, *, allow
         p, role:waffle-k8s-admin, repositories, delete, *, allow
-        g, wafflestudio:waffle-k8s-admin, role:waffle-k8s-admin
+
+        g, wafflestudio:snutt-frontend, role:snutt-frontend
+        p, role:snutt-frontend, applications, *, default/snutt-ev-web, allow
+        p, role:snutt-frontend, applications, *, default/snutt-ev-web-dev, allow
+
+        g, wafflestudio:snutt-server, role:snutt-server
+        p, role:snutt-server, applications, *, default/snutt-core, allow
+        p, role:snutt-server, applications, *, default/snutt-core-dev, allow
+        p, role:snutt-server, applications, *, default/snutt-ev, allow
+        p, role:snutt-server, applications, *, default/snutt-ev-dev, allow
+        p, role:snutt-server, applications, *, default/snutt-ev-batch, allow
+        p, role:snutt-server, applications, *, default/snutt-ev-batch-dev, allow
+        p, role:snutt-server, applications, *, default/snutt-timetable, allow
+        p, role:snutt-server, applications, *, default/snutt-timetable-dev, allow
+        p, role:snutt-server, applications, *, default/snutt-timetable-batch, allow
+        p, role:snutt-server, applications, *, default/snutt-timetable-batch-dev, allow
+        
+        g, wafflestudio:snutt-server, role:snutt-server
+        p, role:snutt-server, applications, *, default/snutt-core, allow
+        p, role:snutt-server, applications, *, default/snutt-core-dev, allow
+        p, role:snutt-server, applications, *, default/snutt-ev, allow
+        p, role:snutt-server, applications, *, default/snutt-ev-dev, allow
+        p, role:snutt-server, applications, *, default/snutt-ev-batch, allow
+        p, role:snutt-server, applications, *, default/snutt-ev-batch-dev, allow
+        p, role:snutt-server, applications, *, default/snutt-timetable, allow
+        p, role:snutt-server, applications, *, default/snutt-timetable-dev, allow
+        p, role:snutt-server, applications, *, default/snutt-timetable-batch, allow
+        p, role:snutt-server, applications, *, default/snutt-timetable-batch-dev, allow
+        
+        g, wafflestudio:waffledotcom-backend, role:waffledotcom-backend
+        p, role:waffledotcom-backend, applications, *, default/waffledotcom-server, allow
+        p, role:waffledotcom-backend, applications, *, default/waffledotcom-server-dev, allow
+        p, role:waffledotcom-backend, applications, *, default/wacruit-judge, allow
+        p, role:waffledotcom-backend, applications, *, default/wacruit-judge-dev, allow
+        p, role:waffledotcom-backend, applications, *, default/wacruit-server, allow
+        p, role:waffledotcom-backend, applications, *, default/wacruit-server-dev, allow
     params:
       server.insecure: true
   server:


### PR DESCRIPTION
AppProject 로 각 팀의 Application 들을 분리하고, AppProject 하위에 권한 policy 들을 예쁘게 정리하고 싶긴 했는데, 지금의 App of Apps 구조에서는 이게 간단히 테스트 및 적용해보는 게 쉽지가 않았습니다.

일단 각 팀 분들께 권한을 드려 각자 자율적인 관리를 더 편하게 빨리 해드리는 게 중요할 거 같고 사실 이 방식도 직관적이고 편한 점도 있어서, 예쁘진 않지만 권한 내용을 한 곳에 때려넣었습니다. 다른 팀들에게도 각 Application 들에 권한을 점차 다 넣어드릴 예정입니다.

Related: #49, https://github.com/wafflestudio/waffle-world/pull/119#issuecomment-1644109647