### PR TITLE
add preserve_host option to wacruit-service

### DIFF
--- a/apps/sso-dev/kong-gateway/kong-config.yaml
+++ b/apps/sso-dev/kong-gateway/kong-config.yaml
@@ -24,5 +24,6 @@ services:
     paths:
     - /api/
     strip_path: false
+    preserve_host: true
   plugins:
   - name: waffle-jwt-authorizer

--- a/apps/sso-prod/kong-gateway/kong-config.yaml
+++ b/apps/sso-prod/kong-gateway/kong-config.yaml
@@ -36,5 +36,6 @@ services:
     paths:
     - /api/
     strip_path: false
+    preserve_host: true
   plugins:
   - name: waffle-jwt-authorizer


### PR DESCRIPTION
wacruit-server 에서 클러스터 외부에서 보내는 요청들의 `request url` 이 kong-gateway를 지나며 cluster ip로 변조되는 이슈를 해결하기 위해 `preserve_host` 옵션을 추가하였습니다.

해당 옵션은 다빈님이 찾아주셨습니다 🧇 🧇 🧇 🙇 
https://docs.konghq.com/kubernetes-ingress-controller/latest/references/annotations/#konghqcompreserve-host