### PR TITLE
hpa cpu target averageUtilization 조절

### DIFF
--- a/apps/snutt-prod/snutt-core/snutt-core.yaml
+++ b/apps/snutt-prod/snutt-core/snutt-core.yaml
@@ -70,7 +70,7 @@ spec:
       name: cpu
       target:
         type: Utilization
-        averageUtilization: 80
+        averageUtilization: 40
 ---
 apiVersion: v1
 kind: ServiceAccount

--- a/apps/snutt-prod/snutt-ev-web/snutt-ev-web.yaml
+++ b/apps/snutt-prod/snutt-ev-web/snutt-ev-web.yaml
@@ -74,7 +74,7 @@ spec:
       name: cpu
       target:
         type: Utilization
-        averageUtilization: 80
+        averageUtilization: 40
 ---
 apiVersion: v1
 kind: Service

--- a/apps/snutt-prod/snutt-ev/snutt-ev.yaml
+++ b/apps/snutt-prod/snutt-ev/snutt-ev.yaml
@@ -82,7 +82,7 @@ spec:
       name: cpu
       target:
         type: Utilization
-        averageUtilization: 80
+        averageUtilization: 40
 ---
 apiVersion: v1
 kind: ServiceAccount

--- a/apps/snutt-prod/snutt-timetable/snutt-timetable.yaml
+++ b/apps/snutt-prod/snutt-timetable/snutt-timetable.yaml
@@ -82,7 +82,7 @@ spec:
       name: cpu
       target:
         type: Utilization
-        averageUtilization: 80
+        averageUtilization: 40
 ---
 apiVersion: v1
 kind: ServiceAccount


### PR DESCRIPTION
grafana 에서 트래픽 튈 때 cpu 그래프 봤을 때, requets 대비 40% 정도로 target 을 잡아야 (또는 더 낮게) 유의미하게 스케일링될 것 같아서 줄임.