### PR TITLE
와커톤 areyouhere 서버 health-check 삭제

### DIFF
--- a/apps/areyouhere/areyouhere-server/areyouhere-server.yaml
+++ b/apps/areyouhere/areyouhere-server/areyouhere-server.yaml
@@ -40,20 +40,6 @@ spec:
               memory: 256Mi
           ports:
             - containerPort: 8080
-          startupProbe:
-            httpGet:
-              path: /actuator/health/startup
-              port: 8080
-            initialDelaySeconds: 10
-            failureThreshold: 20
-          livenessProbe:
-            httpGet:
-              path: /actuator/health/liveness
-              port: 8080
-          readinessProbe:
-            httpGet:
-              path: /actuator/health/readiness
-              port: 8080
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
생각보다 스프링 서버가 켜지는 데 시간이 오래걸려서, 재시작이 반복되네요 ㅠ 해커톤 기간에는 해당 설정을 제외하고 추후 서버를 유지한다면 적절한 설정값을 고려해 보겠습니다!