### PR TITLE
setup babble namespace and argocd

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -24,3 +24,4 @@ apps/seeya/ @wafflestudio/seeya
 apps/snugo/snugo-server/ @wafflestudio/snugo
 apps/areyouhere/ @wafflestudio/areyouhere
 apps/icebreaker/ @PFCjeong @shp7724 @Jhvictor4 @sstto
+apps/babble/ @bugoverdose

--- a/apps/babble/babble-server/deployment.yaml
+++ b/apps/babble/babble-server/deployment.yaml
@@ -1,0 +1,42 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: babble-server
+  labels:
+    app: babble-server
+  namespace: babble
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: babble-server
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 25%
+  revisionHistoryLimit: 4
+  template:
+    metadata:
+      labels:
+        app: babble-server
+    spec:
+      nodeSelector:
+        phase: dev
+      tolerations:
+        - effect: NoSchedule
+          key: phase
+          operator: Equal
+          value: dev
+      containers:
+        - image: 405906814034.dkr.ecr.ap-northeast-2.amazonaws.com/babble/babble-server:1
+          name: babble-server
+          resources:
+            requests:
+              cpu: 100m
+              memory: 256Mi
+            limits:
+              cpu: 200m
+              memory: 256Mi
+          ports:
+            - containerPort: 8080

--- a/apps/babble/babble-server/istio.yaml
+++ b/apps/babble/babble-server/istio.yaml
@@ -1,0 +1,15 @@
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  namespace: babble
+  name: babble-server
+spec:
+  gateways:
+  - istio-ingress/waffle-ingressgateway
+  - mesh
+  hosts:
+  - babble.wafflestudio.com
+  http:
+  - route:
+    - destination:
+        host: babble-server

--- a/apps/babble/babble-server/service.yaml
+++ b/apps/babble/babble-server/service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  namespace: babble
+  name: babble-server
+spec:
+  type: ClusterIP
+  selector:
+    app: babble-server
+  ports:
+    - port: 80
+      targetPort: 8080

--- a/apps/templates/babble-server.yaml
+++ b/apps/templates/babble-server.yaml
@@ -1,0 +1,18 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  namespace: argocd
+  name: babble-server
+  finalizers:
+  - resources-finalizer.argocd.argoproj.io
+spec:
+  project: default
+  source:
+    repoURL: {{ .Values.spec.source.repoURL }}
+    targetRevision: HEAD
+    path: apps/babble/babble-server
+  destination:
+    server: {{ .Values.spec.destination.server }}
+    namespace: argocd
+  syncPolicy:
+    {{- .Values.spec.syncPolicy | toYaml | nindent 4 }}

--- a/misc/apps/namespace.yaml
+++ b/misc/apps/namespace.yaml
@@ -151,3 +151,10 @@ metadata:
   name: areyouhere
   labels:
     istio-injection: enabled
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: babble
+  labels:
+    istio-injection: enabled


### PR DESCRIPTION
안녕하세요. 와카톤 babble팀 k8s 초기 셋업 작업입니다.

현재 [babble-server 저장소](https://github.com/wafflestudio/babble-server/actions
)에 프로젝트 빌드 후 ECR로 푸시하는 깃헙 액션 셋업되었고, 이미지가 제대로 푸시되는 것까지 확인 완료되었습니다. 
- 현재 이미지 태그는 `1`입니다.
- 환경변수는 빌드 시점에 깃헙 액션 secrets에서 가져와 주입합니다.

CODEOWNERS에는 일단 제 깃헙 id를 추가했습니다.

실수하거나 놓친 부분이 있으면 알려주시기 바랍니다. 감사합니다.