### PR TITLE
siksha-server-dev 팀에 대하여 cronjob 수동 실행 권한 부여

### DIFF
--- a/charts/argocd/values.yaml
+++ b/charts/argocd/values.yaml
@@ -66,6 +66,20 @@ argo-cd:
         p, role:siksha, exec, create, default/siksha-crawler, allow
         p, role:siksha, applications, *, default/siksha-crawler-dev, allow
         p, role:siksha, exec, create, default/siksha-crawler-dev, allow
+
+        g, wafflestudio:siksha-server-data, role:siksha-server-data
+        p, role:siksha-server-data, applications, *, default/siksha-api-server, allow
+        p, role:siksha-server-data, exec, create, default/siksha-api-server, allow
+        p, role:siksha-server-data, applications, *, default/siksha-api-server-dev, allow
+        p, role:siksha-server-data, exec, create, default/siksha-api-server-dev, allow
+        p, role:siksha-server-data, applications, *, default/siksha-crawler, allow
+        p, role:siksha-server-data, exec, create, default/siksha-crawler, allow
+        p, role:siksha-server-data, applications, *, default/siksha-crawler-dev, allow
+        p, role:siksha-server-data, exec, create, default/siksha-crawler-dev, allow
+        p, role:siksha-server-data, batch/cronjobs, create, default/siksha-crawler, allow
+        p, role:siksha-server-data, batch/cronjobs, create, default/siksha-crawler-dev, allow
+        p, role:siksha-server-data, batch/jobs, create, default/siksha-crawler, allow
+        p, role:siksha-server-data, batch/jobs, create, default/siksha-crawler-dev, allow
         
         g, wafflestudio:waffledotcom-backend, role:waffledotcom-backend
         p, role:waffledotcom-backend, applications, *, default/waffledotcom-server, allow

--- a/charts/argocd/values.yaml
+++ b/charts/argocd/values.yaml
@@ -76,8 +76,6 @@ argo-cd:
         p, role:siksha-server-data, exec, create, default/siksha-crawler, allow
         p, role:siksha-server-data, applications, *, default/siksha-crawler-dev, allow
         p, role:siksha-server-data, exec, create, default/siksha-crawler-dev, allow
-        p, role:siksha-server-data, jobs, create, default/siksha-crawler, allow
-        p, role:siksha-server-data, jobs, create, default/siksha-crawler-dev, allow
         
         g, wafflestudio:waffledotcom-backend, role:waffledotcom-backend
         p, role:waffledotcom-backend, applications, *, default/waffledotcom-server, allow

--- a/charts/argocd/values.yaml
+++ b/charts/argocd/values.yaml
@@ -76,10 +76,8 @@ argo-cd:
         p, role:siksha-server-data, exec, create, default/siksha-crawler, allow
         p, role:siksha-server-data, applications, *, default/siksha-crawler-dev, allow
         p, role:siksha-server-data, exec, create, default/siksha-crawler-dev, allow
-        p, role:siksha-server-data, batch/cronjobs, create, default/siksha-crawler, allow
-        p, role:siksha-server-data, batch/cronjobs, create, default/siksha-crawler-dev, allow
-        p, role:siksha-server-data, batch/jobs, create, default/siksha-crawler, allow
-        p, role:siksha-server-data, batch/jobs, create, default/siksha-crawler-dev, allow
+        p, role:siksha-server-data, jobs, create, default/siksha-crawler, allow
+        p, role:siksha-server-data, jobs, create, default/siksha-crawler-dev, allow
         
         g, wafflestudio:waffledotcom-backend, role:waffledotcom-backend
         p, role:waffledotcom-backend, applications, *, default/waffledotcom-server, allow


### PR DESCRIPTION
## 목적
- 식샤 백엔드, 데이터 관련 분들에게 `siksha-crawler{-dev}`에 정의되어 있는 cronjob을 수동으로 실행시킬 수 있도록 하기 위한 권한 추가

## 고려사항
- 해당 동작에 대한 권한이 아래 pr을 통해 추가되었는데, 현재 waffle-world의 argo-helm 버전이 해당 pr이 머지되기 전 버전으로 알고 있습니다.
    - 이로 인해 지금 권한 부여 방식이 동작하지 않는다면 모든 namespace에 대한 application create 권한을 주던가 argo-helm의 버전을 올려야 될 거 같은데 이 부분은 고민이 필요해보입니다.

## Reference
- 관련 슬랙 링크: https://wafflestudio.slack.com/archives/C01M4TMNFPX/p1731308194095139
- argo-helm cronjob create 관련 pr 링크: https://github.com/argoproj/argo-helm/pull/2212