### PR TITLE
Add internhasha-server

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -19,3 +19,5 @@ apps/snugo/snugo-server/ @wafflestudio/snugo
 apps/areyouhere/ @wafflestudio/areyouhere
 apps/hodu-dev/ @wafflestudio/hodu
 apps/hodu-prod/ @wafflestudio/hodu
+apps/internhasha-dev/ @wafflestudio/internhasha
+apps/internhasha-prod/ @wafflestudio/internhasha

--- a/apps/internhasha-dev/internhasha/internhasha-server.yaml
+++ b/apps/internhasha-dev/internhasha/internhasha-server.yaml
@@ -1,0 +1,88 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: internhasha-server
+  labels:
+    app: internhasha-server
+  namespace: internhasha-dev
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: internhasha-server
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 25%
+  revisionHistoryLimit: 4
+  template:
+    metadata:
+      labels:
+        app: internhasha-server
+    spec:
+      nodeSelector:
+        phase: dev
+      tolerations:
+        - effect: NoSchedule
+          key: phase
+          operator: Equal
+          value: dev
+      containers:
+        - image: busybox #internhasha/internhasha-server:dev-1
+          command:
+          - sleep
+          - "3600"
+          name: internhasha-server
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+            limits:
+              cpu: 100m
+              memory: 128Mi
+          ports:
+            - containerPort: 8080
+          # startupProbe:
+          #   httpGet:
+          #     path: /actuator/health/startup
+          #     port: 8080
+          #   initialDelaySeconds: 10
+          #   failureThreshold: 20
+          # livenessProbe:
+          #   httpGet:
+          #     path: /actuator/health/liveness
+          #     port: 8080
+          # readinessProbe:
+          #   httpGet:
+          #     path: /actuator/health/readiness
+          #     port: 8080
+---
+apiVersion: v1
+kind: Service
+metadata:
+  namespace: internhasha-dev
+  name: internhasha-server
+spec:
+  type: ClusterIP
+  selector:
+    app: internhasha-server
+  ports:
+    - port: 80
+      targetPort: 8080
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  namespace: internhasha-dev
+  name: internhasha-server
+spec:
+  gateways:
+    - istio-ingress/waffle-ingressgateway
+    - mesh
+  hosts:
+    - dev-api-internhasha.wafflestudio.com
+  http:
+    - route:
+        - destination:
+            host: internhasha-server

--- a/apps/internhasha-dev/internhasha/internhasha-server.yaml
+++ b/apps/internhasha-dev/internhasha/internhasha-server.yaml
@@ -29,10 +29,7 @@ spec:
           operator: Equal
           value: dev
       containers:
-        - image: busybox #internhasha/internhasha-server:dev-1
-          command:
-          - sleep
-          - "3600"
+        - image: 405906814034.dkr.ecr.ap-northeast-2.amazonaws.com/internhasha-dev/internhasha-server:00
           name: internhasha-server
           resources:
             requests:
@@ -43,20 +40,20 @@ spec:
               memory: 128Mi
           ports:
             - containerPort: 8080
-          # startupProbe:
-          #   httpGet:
-          #     path: /actuator/health/startup
-          #     port: 8080
-          #   initialDelaySeconds: 10
-          #   failureThreshold: 20
-          # livenessProbe:
-          #   httpGet:
-          #     path: /actuator/health/liveness
-          #     port: 8080
-          # readinessProbe:
-          #   httpGet:
-          #     path: /actuator/health/readiness
-          #     port: 8080
+          startupProbe:
+            httpGet:
+              path: /actuator/health/startup
+              port: 8080
+            initialDelaySeconds: 10
+            failureThreshold: 20
+          livenessProbe:
+            httpGet:
+              path: /actuator/health/liveness
+              port: 8080
+          readinessProbe:
+            httpGet:
+              path: /actuator/health/readiness
+              port: 8080
 ---
 apiVersion: v1
 kind: Service

--- a/apps/internhasha-prod/internhasha/internhasha-server.yaml
+++ b/apps/internhasha-prod/internhasha/internhasha-server.yaml
@@ -29,11 +29,8 @@ spec:
           operator: Equal
           value: prod
       containers:
-        - image: busybox #internhasha/internhasha-server:prod-1
-          command:
-          - sleep
-          - "3600"
-          name: internhasha-server 
+        - image: 405906814034.dkr.ecr.ap-northeast-2.amazonaws.com/internhasha-prod/internhasha-server:v.250504
+          name: internhasha-server
           resources:
             requests:
               cpu: 200m
@@ -43,21 +40,20 @@ spec:
               memory: 256Mi
           ports:
             - containerPort: 8080
-          # 실제 이미지로 교체 후 적용
-          # startupProbe:
-          #   httpGet:
-          #     path: /actuator/health/startup
-          #     port: 8080
-          #   initialDelaySeconds: 10
-          #   failureThreshold: 20
-          # livenessProbe:
-          #   httpGet:
-          #     path: /actuator/health/liveness
-          #     port: 8080
-          # readinessProbe:
-          #   httpGet:
-          #     path: /actuator/health/readiness
-          #     port: 8080
+          startupProbe:
+            httpGet:
+              path: /actuator/health/startup
+              port: 8080
+            initialDelaySeconds: 10
+            failureThreshold: 20
+          livenessProbe:
+            httpGet:
+              path: /actuator/health/liveness
+              port: 8080
+          readinessProbe:
+            httpGet:
+              path: /actuator/health/readiness
+              port: 8080
 ---
 apiVersion: v1
 kind: Service

--- a/apps/internhasha-prod/internhasha/internhasha-server.yaml
+++ b/apps/internhasha-prod/internhasha/internhasha-server.yaml
@@ -1,0 +1,89 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: internhasha-server
+  labels:
+    app: internhasha-server
+  namespace: internhasha-prod
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: internhasha-server
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 25%
+  revisionHistoryLimit: 4
+  template:
+    metadata:
+      labels:
+        app: internhasha-server
+    spec:
+      nodeSelector:
+        phase: prod
+      tolerations:
+        - effect: NoSchedule
+          key: phase
+          operator: Equal
+          value: prod
+      containers:
+        - image: busybox #internhasha/internhasha-server:prod-1
+          command:
+          - sleep
+          - "3600"
+          name: internhasha-server 
+          resources:
+            requests:
+              cpu: 200m
+              memory: 256Mi
+            limits:
+              cpu: 200m
+              memory: 256Mi
+          ports:
+            - containerPort: 8080
+          # 실제 이미지로 교체 후 적용
+          # startupProbe:
+          #   httpGet:
+          #     path: /actuator/health/startup
+          #     port: 8080
+          #   initialDelaySeconds: 10
+          #   failureThreshold: 20
+          # livenessProbe:
+          #   httpGet:
+          #     path: /actuator/health/liveness
+          #     port: 8080
+          # readinessProbe:
+          #   httpGet:
+          #     path: /actuator/health/readiness
+          #     port: 8080
+---
+apiVersion: v1
+kind: Service
+metadata:
+  namespace: internhasha-prod
+  name: internhasha-server
+spec:
+  type: ClusterIP
+  selector:
+    app: internhasha-server
+  ports:
+    - port: 80
+      targetPort: 8080
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  namespace: internhasha-prod
+  name: internhasha-server
+spec:
+  gateways:
+    - istio-ingress/waffle-ingressgateway
+    - mesh
+  hosts:
+    - api-internhasha.wafflestudio.com
+  http:
+    - route:
+        - destination:
+            host: internhasha-server

--- a/apps/templates/internhasha-dev.yaml
+++ b/apps/templates/internhasha-dev.yaml
@@ -1,0 +1,18 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  namespace: argocd
+  name: internhasha-dev
+  finalizers:
+  - resources-finalizer.argocd.argoproj.io
+spec:
+  project: default
+  source:
+    repoURL: {{ .Values.spec.source.repoURL }}
+    targetRevision: HEAD
+    path: apps/internhasha-dev/internhasha
+  destination:
+    server: {{ .Values.spec.destination.server }}
+    namespace: argocd
+  syncPolicy:
+    {{- .Values.spec.syncPolicy | toYaml | nindent 4 }}

--- a/apps/templates/internhasha.yaml
+++ b/apps/templates/internhasha.yaml
@@ -1,0 +1,18 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  namespace: argocd
+  name: internhasha
+  finalizers:
+  - resources-finalizer.argocd.argoproj.io
+spec:
+  project: default
+  source:
+    repoURL: {{ .Values.spec.source.repoURL }}
+    targetRevision: HEAD
+    path: apps/internhasha-prod/internhasha
+  destination:
+    server: {{ .Values.spec.destination.server }}
+    namespace: argocd
+  syncPolicy:
+    {{- .Values.spec.syncPolicy | toYaml | nindent 4 }}

--- a/misc/apps/namespace.yaml
+++ b/misc/apps/namespace.yaml
@@ -109,3 +109,17 @@ metadata:
   name: hodu-prod
   labels:
     istio-injection: enabled
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: internhasha-dev
+  labels:
+    istio-injection: enabled
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: internhasha-prod
+  labels:
+    istio-injection: enabled


### PR DESCRIPTION
인턴하샤 서버인 internhasha-server 배포를 위한 PR입니다.

[서버 레포](https://github.com/wafflestudio/internhasha-server)입니다.

다음 두 PR을 참고하여 작성하였습니다. 이번에 처음 작성하게 되어 부족한 부분이 있을 수 있습니다.
- https://github.com/wafflestudio/waffle-world/pull/190
- https://github.com/wafflestudio/waffle-world/pull/162

+ startupProbe 부분은 spring actuator 적용, 세 엔드포인트 모두 확인하였습니다.

이번 PR과 관련된 질문을 몇 가지 드립니다!
1. CODEOWNERS의 @wafflestudio/internhasha 팀 설정이 아직 안 되어 있습니다. 직접 팀 생성이 안 되는 것 같은데 인프라 팀에 요청하여 생성하면 되는 것인지 궁금합니다.
2. 개발과 배포 각각의 이미지는 임시로 ecr에 올린 이미지를 지정하였습니다. 앞으로 태그 기반으로 업데이트를 할 예정인데, 아직 [ecr-heimdall](https://github.com/wafflestudio/ecr-heimdall)에 대한 설정이 되어 있지 않습니다. 만약 해당 레포 적용 없이 업데이트를 하려면 waffle-world에 매번 pr을 하여 갱신을 하여야하는지 궁금합니다.(혹시 다른 방법이 있을까요?)
3. cpu, memory 스펙은 일단 다른 manifest 파일을 참고해가며 임의로 설정하였습니다. 현재 단계에서 이 정도면 충분할까요?
    - dev는 cpu: 100m, memory: 128Mi
    - prod는 cpu: 200m, memory: 256Mi 