### PR TITLE
[인턴하샤] dev 서버 메모리 조정

### DIFF
--- a/apps/internhasha-dev/internhasha/internhasha-server.yaml
+++ b/apps/internhasha-dev/internhasha/internhasha-server.yaml
@@ -39,11 +39,11 @@ spec:
               value: "dev"
           resources:
             requests:
-              cpu: 200m
-              memory: 768Mi
+              cpu: 100m
+              memory: 512Mi
             limits:
-              cpu: 400m
-              memory: 768Mi
+              cpu: 200m
+              memory: 512Mi
           ports:
             - containerPort: 8080
           startupProbe:

--- a/apps/internhasha-dev/internhasha/internhasha-server.yaml
+++ b/apps/internhasha-dev/internhasha/internhasha-server.yaml
@@ -34,7 +34,7 @@ spec:
           name: internhasha-server
           env:
             - name: JAVA_OPTS
-              value: "-XX:InitialRAMPercentage=80.0 -XX:MaxRAMPercentage=80.0
+              value: "-XX:InitialRAMPercentage=80.0 -XX:MaxRAMPercentage=80.0"
             - name: SPRING_PROFILES_ACTIVE
               value: "dev"
           resources:

--- a/apps/internhasha-dev/internhasha/internhasha-server.yaml
+++ b/apps/internhasha-dev/internhasha/internhasha-server.yaml
@@ -39,11 +39,11 @@ spec:
               value: "dev"
           resources:
             requests:
-              cpu: 100m
-              memory: 256Mi
+              cpu: 200m
+              memory: 768Mi
             limits:
-              cpu: 100m
-              memory: 256Mi
+              cpu: 400m
+              memory: 768Mi
           ports:
             - containerPort: 8080
           startupProbe:

--- a/apps/internhasha-dev/internhasha/internhasha-server.yaml
+++ b/apps/internhasha-dev/internhasha/internhasha-server.yaml
@@ -31,6 +31,9 @@ spec:
       containers:
         - image: 405906814034.dkr.ecr.ap-northeast-2.amazonaws.com/internhasha-dev/internhasha-server:00
           name: internhasha-server
+          env:
+            - name: SPRING_PROFILES_ACTIVE
+              value: "dev"
           resources:
             requests:
               cpu: 100m
@@ -54,6 +57,14 @@ spec:
             httpGet:
               path: /actuator/health/readiness
               port: 8080
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: internhasha
+  namespace: internhasha-dev
+  annotations:
+    eks.amazonaws.com/role-arn: arn:aws:iam::405906814034:role/internhasha-dev-role
 ---
 apiVersion: v1
 kind: Service

--- a/apps/internhasha-dev/internhasha/internhasha-server.yaml
+++ b/apps/internhasha-dev/internhasha/internhasha-server.yaml
@@ -21,6 +21,7 @@ spec:
       labels:
         app: internhasha-server
     spec:
+      serviceAccountName: internhasha
       nodeSelector:
         phase: dev
       tolerations:

--- a/apps/internhasha-dev/internhasha/internhasha-server.yaml
+++ b/apps/internhasha-dev/internhasha/internhasha-server.yaml
@@ -6,7 +6,7 @@ metadata:
     app: internhasha-server
   namespace: internhasha-dev
 spec:
-  replicas: 0
+  replicas: 1
   selector:
     matchLabels:
       app: internhasha-server

--- a/apps/internhasha-dev/internhasha/internhasha-server.yaml
+++ b/apps/internhasha-dev/internhasha/internhasha-server.yaml
@@ -33,15 +33,17 @@ spec:
         - image: 405906814034.dkr.ecr.ap-northeast-2.amazonaws.com/internhasha-dev/internhasha-server:00
           name: internhasha-server
           env:
+            - name: JAVA_OPTS
+              value: "-XX:InitialRAMPercentage=80.0 -XX:MaxRAMPercentage=80.0
             - name: SPRING_PROFILES_ACTIVE
               value: "dev"
           resources:
             requests:
               cpu: 100m
-              memory: 128Mi
+              memory: 256Mi
             limits:
               cpu: 100m
-              memory: 128Mi
+              memory: 256Mi
           ports:
             - containerPort: 8080
           startupProbe:

--- a/apps/internhasha-dev/internhasha/internhasha-server.yaml
+++ b/apps/internhasha-dev/internhasha/internhasha-server.yaml
@@ -6,7 +6,7 @@ metadata:
     app: internhasha-server
   namespace: internhasha-dev
 spec:
-  replicas: 1
+  replicas: 0
   selector:
     matchLabels:
       app: internhasha-server

--- a/apps/internhasha-prod/internhasha/internhasha-server.yaml
+++ b/apps/internhasha-prod/internhasha/internhasha-server.yaml
@@ -31,6 +31,9 @@ spec:
       containers:
         - image: 405906814034.dkr.ecr.ap-northeast-2.amazonaws.com/internhasha-prod/internhasha-server:v.250504
           name: internhasha-server
+          env:
+            - name: SPRING_PROFILES_ACTIVE
+              value: "prod"
           resources:
             requests:
               cpu: 200m
@@ -54,6 +57,14 @@ spec:
             httpGet:
               path: /actuator/health/readiness
               port: 8080
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: internhasha
+  namespace: internhasha-prod
+  annotations:
+    eks.amazonaws.com/role-arn: arn:aws:iam::405906814034:role/internhasha-prod-role
 ---
 apiVersion: v1
 kind: Service

--- a/apps/internhasha-prod/internhasha/internhasha-server.yaml
+++ b/apps/internhasha-prod/internhasha/internhasha-server.yaml
@@ -21,6 +21,7 @@ spec:
       labels:
         app: internhasha-server
     spec:
+      serviceAccountName: internhasha
       nodeSelector:
         phase: prod
       tolerations:

--- a/apps/internhasha-prod/internhasha/internhasha-server.yaml
+++ b/apps/internhasha-prod/internhasha/internhasha-server.yaml
@@ -34,7 +34,7 @@ spec:
           name: internhasha-server
           env:
             - name: JAVA_OPTS
-              value: "-XX:InitialRAMPercentage=80.0 -XX:MaxRAMPercentage=80.0
+              value: "-XX:InitialRAMPercentage=80.0 -XX:MaxRAMPercentage=80.0"
             - name: SPRING_PROFILES_ACTIVE
               value: "prod"
           resources:

--- a/apps/internhasha-prod/internhasha/internhasha-server.yaml
+++ b/apps/internhasha-prod/internhasha/internhasha-server.yaml
@@ -6,7 +6,7 @@ metadata:
     app: internhasha-server
   namespace: internhasha-prod
 spec:
-  replicas: 0
+  replicas: 1
   selector:
     matchLabels:
       app: internhasha-server

--- a/apps/internhasha-prod/internhasha/internhasha-server.yaml
+++ b/apps/internhasha-prod/internhasha/internhasha-server.yaml
@@ -33,6 +33,8 @@ spec:
         - image: 405906814034.dkr.ecr.ap-northeast-2.amazonaws.com/internhasha-prod/internhasha-server:v.250504
           name: internhasha-server
           env:
+            - name: JAVA_OPTS
+              value: "-XX:InitialRAMPercentage=80.0 -XX:MaxRAMPercentage=80.0
             - name: SPRING_PROFILES_ACTIVE
               value: "prod"
           resources:

--- a/apps/internhasha-prod/internhasha/internhasha-server.yaml
+++ b/apps/internhasha-prod/internhasha/internhasha-server.yaml
@@ -6,7 +6,7 @@ metadata:
     app: internhasha-server
   namespace: internhasha-prod
 spec:
-  replicas: 1
+  replicas: 0
   selector:
     matchLabels:
       app: internhasha-server

--- a/apps/internhasha-prod/internhasha/internhasha-server.yaml
+++ b/apps/internhasha-prod/internhasha/internhasha-server.yaml
@@ -40,10 +40,10 @@ spec:
           resources:
             requests:
               cpu: 200m
-              memory: 256Mi
+              memory: 768Mi
             limits:
-              cpu: 200m
-              memory: 256Mi
+              cpu: 400m
+              memory: 768Mi
           ports:
             - containerPort: 8080
           startupProbe:


### PR DESCRIPTION
- 아래 이벤트 로그에서 보이는 노드 메모리 부족으로 인한 파드 추가 실패를 방지하기 위해 dev 서버의 요청 메모리를 감소시켰습니다.

> 0/7 nodes are available: 2 Insufficient memory, 2 node(s) didn't match Pod's node affinity/selector, 3 node(s) had untolerated taint {phase: prod}. preemption: 0/7 nodes are available: 2 No preemption victims found for incoming pod, 5 Preemption is not helpful for scheduling.