### PR TITLE
Feat : ArgoCD Sync 완료시 Pupuri-bot 엔드포인트로 웹훅 전송

### DIFF
--- a/apps/wacruit-prod/wacruit-server/wacruit-server.yaml
+++ b/apps/wacruit-prod/wacruit-server/wacruit-server.yaml
@@ -5,6 +5,8 @@ metadata:
   labels:
     app: wacruit-server
   namespace: wacruit-prod
+  annotations:
+    notifications.argoproj.io/subscribe.sync-completed.pupuri-bot: "true"
 spec:
   replicas: 1
   selector:
@@ -70,11 +72,11 @@ metadata:
   name: wacruit-server
 spec:
   gateways:
-  - istio-ingress/waffle-ingressgateway
-  - mesh
+    - istio-ingress/waffle-ingressgateway
+    - mesh
   hosts:
-  - wacruit-server.wacruit-prod.svc.cluster.local
+    - wacruit-server.wacruit-prod.svc.cluster.local
   http:
-  - route:
-    - destination:
-        host: wacruit-server
+    - route:
+        - destination:
+            host: wacruit-server

--- a/charts/argocd/templates/argocd-notifications-cm.yaml
+++ b/charts/argocd/templates/argocd-notifications-cm.yaml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: argocd-notifications-cm
+  namespace: argocd
+data:
+  service.webhook.pupuri-bot: |
+    url: https://pupuri-bot.wafflestudio.com/argocd/webhook-endpoint
+    method: POST
+    headers:
+    - name: Content-Type
+      value: application/json
+
+  template.sync-completed: |
+    {
+      "namespace": "{{.app.metadata.namespace}}",
+      "app":       "{{.app.metadata.name}}"
+    }
+
+  trigger.sync-completed: |
+    - description: Application sync completed
+      oncePer: app
+      send:
+        - webhook:pupuri-bot
+      when: app.status.operationState.phase in ['Succeeded']
+
+  subscription.sync-completed: |
+    recipients:
+      - pupuri-bot


### PR DESCRIPTION
ArgoCD 에서 Sync 가 완료되었을 때 https://pupuri-bot.wafflestudio.com/argocd/webhook-endpoint 에 namespace 와 app 정보를 body 에 JSON 형태로 담아 POST 요청으로 웹훅을 보낼 수 있도록,
template 을 생성하였습니다.
이를 테스트 하기 위하여 `wacruit-server.yaml`에 어노테이션을 추가하였고, 
ArgoCD에서 해당 Service를 Refresh > Sync를 완료하여 pupuri bot으로 웹훅 전송이 되어 슬랙에 메시지로 뜨는지 확인해보고자 합니다.
