### PR TITLE
Infra : argocd/values.yaml 에 app, namespace argocd 추가

### DIFF
--- a/apps/wacruit-prod/wacruit-server/wacruit-server.yaml
+++ b/apps/wacruit-prod/wacruit-server/wacruit-server.yaml
@@ -5,6 +5,8 @@ metadata:
   labels:
     app: wacruit-server
   namespace: wacruit-prod
+  annotations:
+    notifications.argoproj.io/subscribe.sync-completed.pupuri-bot: "true"
 spec:
   replicas: 1
   selector:
@@ -70,11 +72,11 @@ metadata:
   name: wacruit-server
 spec:
   gateways:
-  - istio-ingress/waffle-ingressgateway
-  - mesh
+    - istio-ingress/waffle-ingressgateway
+    - mesh
   hosts:
-  - wacruit-server.wacruit-prod.svc.cluster.local
+    - wacruit-server.wacruit-prod.svc.cluster.local
   http:
-  - route:
-    - destination:
-        host: wacruit-server
+    - route:
+        - destination:
+            host: wacruit-server

--- a/charts/argocd/templates/argocd-notifications-cm.yaml
+++ b/charts/argocd/templates/argocd-notifications-cm.yaml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: argocd-notifications-cm
+  namespace: argocd
+data:
+  service.webhook.pupuri-bot: |
+    url: https://pupuri-bot.wafflestudio.com/argocd/webhook-endpoint
+    method: POST
+    headers:
+    - name: Content-Type
+      value: application/json
+
+  template.sync-completed: |
+    {
+      "namespace": "{{.app.metadata.namespace}}",
+      "app":       "{{.app.metadata.name}}"
+    }
+
+  trigger.sync-completed: |
+    - description: Application sync completed
+      oncePer: app
+      send:
+        - webhook:pupuri-bot
+      when: app.status.operationState.phase in ['Succeeded']
+
+  subscription.sync-completed: |
+    recipients:
+      - pupuri-bot

--- a/charts/argocd/values.yaml
+++ b/charts/argocd/values.yaml
@@ -1,3 +1,6 @@
+app:
+  metadata:
+    namespace: argocd
 argo-cd:
   configs:
     cm:
@@ -26,7 +29,7 @@ argo-cd:
         p, role:waffle-k8s-admin, repositories, update, *, allow
         p, role:waffle-k8s-admin, repositories, delete, *, allow
         p, role:waffle-k8s-admin, exec, create, */*, allow
-        
+
         g, wafflestudio:snutt-server, role:snutt-server
         p, role:snutt-server, applications, *, default/snutt-ev, allow
         p, role:snutt-server, exec, create, default/snutt-ev, allow
@@ -44,7 +47,7 @@ argo-cd:
         p, role:snutt-server, exec, create, default/snutt-timetable-batch, allow
         p, role:snutt-server, applications, *, default/snutt-timetable-batch-dev, allow
         p, role:snutt-server, exec, create, default/snutt-timetable-batch-dev, allow
-        
+
         g, wafflestudio:snutt-frontend, role:snutt-frontend
         p, role:snutt-frontend, applications, *, default/snutt-ev-web, allow
         p, role:snutt-frontend, exec, create, default/snutt-ev-web, allow
@@ -78,7 +81,7 @@ argo-cd:
         p, role:siksha-server-data, exec, create, default/siksha-crawler-dev, allow
         p, role:siksha-server-data, applications, *, default/siksha-spring-server-dev, allow
         p, role:siksha-server-data, exec, create, default/siksha-spring-server-dev, allow
-        
+
         g, wafflestudio:waffledotcom-backend, role:waffledotcom-backend
         p, role:waffledotcom-backend, applications, *, default/waffledotcom-server, allow
         p, role:waffledotcom-backend, exec, create, default/waffledotcom-server, allow
@@ -92,11 +95,11 @@ argo-cd:
         p, role:waffledotcom-backend, exec, create, default/wacruit-server, allow
         p, role:waffledotcom-backend, applications, *, default/wacruit-server-dev, allow
         p, role:waffledotcom-backend, exec, create, default/wacruit-server-dev, allow
-        
+
         g, wafflestudio:pupuri, role:pupuri
         p, role:pupuri, applications, *, default/pupuri-bot, allow
         p, role:pupuri, exec, create, default/pupuri-bot, allow
-        
+
         g, wafflestudio:sso, role:sso
         p, role:sso, applications, *, default/sso-kong-gateway, allow
         p, role:sso, exec, create, default/sso-kong-gateway, allow
@@ -106,7 +109,7 @@ argo-cd:
         p, role:sso, exec, create, default/sso-account-server, allow
         p, role:sso, applications, *, default/sso-account-server-dev, allow
         p, role:sso, exec, create, default/sso-account-server-dev, allow
-        
+
         g, wafflestudio:areyouhere, role:areyouhere
         p, role:areyouhere, applications, *, default/areyouhere-server, allow
         p, role:areyouhere, exec, create, default/areyouhere-server, allow


### PR DESCRIPTION
- `helm upgrade argocd charts/argocd -f charts/argocd/values.yaml -n argocd --dry-run --debug` 명령 수행시 아래와 같은 로그가 발생하였습니다
- 수정을 위해, `charts/argocd/values.yaml`에 nil-pointer 방지를 위하여 `app:` 블록을 추가하였습니다.

```
> helm upgrade argocd charts/argocd -f charts/argocd/values.yaml -n argocd --dry-run --debug
upgrade.go:142: [debug] preparing upgrade for argocd
coalesce.go:175: warning: skipped value for argocd.argo-cd.redis-ha.affinity: Not a table.
coalesce.go:223: warning: destination for argocd.argo-cd.redis-ha.haproxy.affinity is a table. Ignoring non-table value ()
coalesce.go:223: warning: destination for argo-cd.redis-ha.haproxy.affinity is a table. Ignoring non-table value ()
coalesce.go:175: warning: skipped value for argo-cd.redis-ha.affinity: Not a table.
Error: UPGRADE FAILED: template: argocd/templates/argocd-notifications-cm.yaml:16:26: executing "argocd/templates/argocd-notifications-cm.yaml" at <.app.metadata.namespace>: nil pointer evaluating interface {}.metadata
helm.go:84: [debug] template: argocd/templates/argocd-notifications-cm.yaml:16:26: executing "argocd/templates/argocd-notifications-cm.yaml" at <.app.metadata.namespace>: nil pointer evaluating interface {}.metadata
UPGRADE FAILED
main.newUpgradeCmd.func2
        helm.sh/helm/v3/cmd/helm/upgrade.go:202
github.com/spf13/cobra.(*Command).execute
        github.com/spf13/cobra@v1.6.1/command.go:916
github.com/spf13/cobra.(*Command).ExecuteC
        github.com/spf13/cobra@v1.6.1/command.go:1044
github.com/spf13/cobra.(*Command).Execute
        github.com/spf13/cobra@v1.6.1/command.go:968
main.main
        helm.sh/helm/v3/cmd/helm/helm.go:83
runtime.main
        runtime/proc.go:250
runtime.goexit
        runtime/asm_arm64.s:1270
```