### PR TITLE
Fix : yaml 파일 문법 오류 수정

### DIFF
--- a/apps/templates/wacruit-server.yaml
+++ b/apps/templates/wacruit-server.yaml
@@ -4,7 +4,7 @@ metadata:
   namespace: argocd
   name: wacruit-server
   annotations:
-    notifications.argoproj.io/subscribe.sync-completed.pupuri-bot:"true"
+    notifications.argoproj.io/subscribe.sync-completed.pupuri-bot: "true"
   finalizers:
   - resources-finalizer.argocd.argoproj.io
 spec:

--- a/charts/argocd/templates/argocd-notifications-cm.yaml
+++ b/charts/argocd/templates/argocd-notifications-cm.yaml
@@ -24,6 +24,6 @@ data:
         - webhook:pupuri-bot
       when: app.status.operationState.phase in ['Succeeded']
 
-  subscription.sync-completed: |
+  subscriptions.sync-completed: |
     recipients:
       - pupuri-bot


### PR DESCRIPTION
### 오류 원인
지난번 PR 이후, Sync 시에도 slack `deploy-watcher` 채널에 알림이 오지 않았습니다.
ArgoCD Notification 작동을 5단계로 분류하였을때
1. Application 상태 변화 감지 
2. Subscription (argocd 어플리케이션의 어노테이션) 매칭
3. Trigger( 조건 평가 )
4. template 렌더링후 service 전송

1번단계에서 application에서 annotation이 빠졌음을 다음과 같이 확인하였습니다.  (k9s -> namespace: argocd -> app에서 wacruit-server)
<img width="642" alt="스크린샷 2025-06-25 오전 12 21 54" src="https://github.com/user-attachments/assets/02824a22-60bb-40aa-aa93-c6ab3c0d211f" />

또한, configmap 작성이 되어있는 `argocd-notification-cm` yaml 파일에서 subscriptions 또한 공식문서 토대로 단수형 -> 복수혀응로 작성되어야 argocd notification controller가 인식할 수 있기에, 이를 수정하여 PR 올립니다. 