### PR TITLE
memowithtags - prod replicas를 1로 조정

### DIFF
--- a/apps/memowithtags-prod/memowithtags/memowithtags-server.yaml
+++ b/apps/memowithtags-prod/memowithtags/memowithtags-server.yaml
@@ -6,7 +6,7 @@ metadata:
     app: memowithtags-server
   namespace: memowithtags-prod
 spec:
-  replicas: 0
+  replicas: 1
   selector:
     matchLabels:
       app: memowithtags-server


### PR DESCRIPTION
memowithtags의 prod 서버를 사용하기 위해 replicas를 1로 조정하였습니다.