### PR TITLE
aws-auth.yaml에서 졸업생 IAM 제거

### DIFF
--- a/misc/kube-system/configmap/aws-auth.yaml
+++ b/misc/kube-system/configmap/aws-auth.yaml
@@ -22,24 +22,12 @@ data:
       groups:
       - system:masters
       - snutt-developers
-    - username: kevin990222
-      userarn: arn:aws:iam::405906814034:user/kevin990222
-      groups:
-      - system:masters
-    - username: eastshine2741
-      userarn: arn:aws:iam::405906814034:user/eastshine2741
-      groups:
-      - system:masters
     - username: anandashin
       userarn: arn:aws:iam::405906814034:user/anandashin
       groups:
       - system:masters
     - username: JunBye
       userarn: arn:aws:iam::405906814034:user/JunBye
-      groups:
-      - system:masters
-    - username: huGgW
-      userarn: arn:aws:iam::405906814034:user/huGgW
       groups:
       - system:masters
     - username: gs18113


### PR DESCRIPTION
인프라팀 활동 종료하신 분들의 IAM 계정 권한을 삭제하는 PR입니다!

커밋은 기록용이고 별도로 kubectl apply할 예정입니다.