### PR TITLE
fix : argocd notification 문법 오류 수정

### DIFF
--- a/charts/argocd/templates/argocd-notifications-cm.yaml
+++ b/charts/argocd/templates/argocd-notifications-cm.yaml
@@ -5,25 +5,25 @@ metadata:
   namespace: argocd
 data:
   service.webhook.pupuri-bot: |
-    url: https://pupuri-bot.wafflestudio.com/argocd/webhook-endpoint
+    url: https://pupuri-api.wafflestudio.com/argocd/webhook-endpoint
     method: POST
     headers:
-    - name: Content-Type
-      value: application/json
+      - name: Content-Type
+        value: application/json
 
-  template.sync-completed: |
-    {{`{
-      "namespace": "{{.app.metadata.namespace}}",
-      "app":       "{{.app.metadata.name}}"
-    }`}}
+  templates.sync-completed: |-
+    {{`{"namespace":"`}}{{"{{.app.metadata.namespace}}"}}{{`","app":"`}}{{"{{.app.metadata.name}}"}}{{`"}`}}
 
-  trigger.sync-completed: |
+  triggers.sync-completed: |-
     - description: Application sync completed
       oncePer: app
+      when: app.status.operationState.phase in ['Succeeded']
       send:
         - webhook:pupuri-bot
-      when: app.status.operationState.phase in ['Succeeded']
 
-  subscriptions.sync-completed: |
+  subscriptions.sync-completed: |-
     recipients:
       - pupuri-bot
+
+  controller.disableAnnotations: "true"
+


### PR DESCRIPTION
기존 Helm Upgrade로 로컬에서 반영 하여 argocd-notification-cm의 문법적 오류를 수정하였습니다.
이에 대한 PR 올립니다. (클러스터에는 반영된 상태로, pupuri-bot 엔드포인트로 argocd application sync시 post 요청이 보내집니다)
