### PR TITLE
fix: k8s-monitoring 이미지 버전

### DIFF
--- a/apps/k8s-monitoring/k8s-monitoring-app/app.yaml
+++ b/apps/k8s-monitoring/k8s-monitoring-app/app.yaml
@@ -30,7 +30,7 @@ spec:
           operator: Equal
           value: prod
       containers:
-        - image: 405906814034.dkr.ecr.ap-northeast-2.amazonaws.com/k8s-monitoring:0.0.1
+        - image: 405906814034.dkr.ecr.ap-northeast-2.amazonaws.com/k8s-monitoring:0.0.3
           imagePullPolicy: Always
           name: app
           envFrom:


### PR DESCRIPTION
ecr 정리할때 0.0.1 이미지가 삭제돼서 현재 imagepullbackoff 상태라 ecr에 올라가 있는 0.0.3으로 버전을 바꿨습니다.