### PR TITLE
모든 yaml에 적절한 arch nodeselector 추가

### DIFF
--- a/apps/areyouhere/areyouhere-server/areyouhere-server.yaml
+++ b/apps/areyouhere/areyouhere-server/areyouhere-server.yaml
@@ -22,6 +22,7 @@ spec:
         app: areyouhere-server
     spec:
       nodeSelector:
+        kubernetes.io/arch: amd64
         phase: dev
       tolerations:
         - effect: NoSchedule

--- a/apps/hodu-dev/hodu/hodu-server.yaml
+++ b/apps/hodu-dev/hodu/hodu-server.yaml
@@ -23,6 +23,7 @@ spec:
     spec:
       serviceAccountName: hodu-server
       nodeSelector:
+        kubernetes.io/arch: amd64
         phase: dev
       tolerations:
         - effect: NoSchedule

--- a/apps/hodu-prod/hodu/hodu-server.yaml
+++ b/apps/hodu-prod/hodu/hodu-server.yaml
@@ -23,6 +23,7 @@ spec:
     spec:
       serviceAccountName: hodu-server
       nodeSelector:
+        kubernetes.io/arch: amd64
         phase: prod
       tolerations:
         - effect: NoSchedule

--- a/apps/internhasha-dev/internhasha/internhasha-server.yaml
+++ b/apps/internhasha-dev/internhasha/internhasha-server.yaml
@@ -23,6 +23,7 @@ spec:
     spec:
       serviceAccountName: internhasha
       nodeSelector:
+        kubernetes.io/arch: arm64
         phase: dev
       tolerations:
         - effect: NoSchedule

--- a/apps/internhasha-prod/internhasha/internhasha-server.yaml
+++ b/apps/internhasha-prod/internhasha/internhasha-server.yaml
@@ -23,6 +23,7 @@ spec:
     spec:
       serviceAccountName: internhasha
       nodeSelector:
+        kubernetes.io/arch: amd64
         phase: prod
       tolerations:
         - effect: NoSchedule

--- a/apps/k8s-monitoring/k8s-monitoring-app/app.yaml
+++ b/apps/k8s-monitoring/k8s-monitoring-app/app.yaml
@@ -23,6 +23,7 @@ spec:
     spec:
       serviceAccountName: k8s-monitoring-sa
       nodeSelector:
+        kubernetes.io/arch: amd64
         phase: prod
       tolerations:
         - effect: NoSchedule

--- a/apps/memowithtags-dev/memowithtags/memowithtags-server.yaml
+++ b/apps/memowithtags-dev/memowithtags/memowithtags-server.yaml
@@ -23,6 +23,7 @@ spec:
     spec:
       serviceAccountName: memowithtags
       nodeSelector:
+        kubernetes.io/arch: amd64
         phase: dev
       tolerations:
         - effect: NoSchedule

--- a/apps/memowithtags-prod/memowithtags/memowithtags-server.yaml
+++ b/apps/memowithtags-prod/memowithtags/memowithtags-server.yaml
@@ -23,6 +23,7 @@ spec:
     spec:
       serviceAccountName: memowithtags
       nodeSelector:
+        kubernetes.io/arch: amd64
         phase: prod
       tolerations:
         - effect: NoSchedule

--- a/apps/pupuri-prod/pupuri-bot/pupuri-bot.yaml
+++ b/apps/pupuri-prod/pupuri-bot/pupuri-bot.yaml
@@ -22,6 +22,7 @@ spec:
         app: pupuri-bot
     spec:
       nodeSelector:
+        kubernetes.io/arch: amd64
         phase: prod
       tolerations:
         - effect: NoSchedule

--- a/apps/siksha-dev/siksha-api-server/siksha-api-server.yaml
+++ b/apps/siksha-dev/siksha-api-server/siksha-api-server.yaml
@@ -23,6 +23,7 @@ spec:
     spec:
       serviceAccountName: siksha-api-server
       nodeSelector:
+        kubernetes.io/arch: amd64
         phase: dev
       tolerations:
         - effect: NoSchedule

--- a/apps/siksha-dev/siksha-crawler/siksha-crawler.yaml
+++ b/apps/siksha-dev/siksha-crawler/siksha-crawler.yaml
@@ -18,6 +18,7 @@ spec:
             sidecar.istio.io/inject: "false"
         spec:
           nodeSelector:
+            kubernetes.io/arch: amd64
             phase: batch
           tolerations:
             - effect: NoSchedule

--- a/apps/siksha-dev/siksha-spring-server/siksha-spring-server.yaml
+++ b/apps/siksha-dev/siksha-spring-server/siksha-spring-server.yaml
@@ -23,6 +23,7 @@ spec:
     spec:
       serviceAccountName: siksha-spring-server
       nodeSelector:
+        kubernetes.io/arch: amd64
         phase: dev
       tolerations:
         - effect: NoSchedule

--- a/apps/siksha-prod/siksha-api-server/siksha-api-server.yaml
+++ b/apps/siksha-prod/siksha-api-server/siksha-api-server.yaml
@@ -23,6 +23,7 @@ spec:
     spec:
       serviceAccountName: siksha-api-server
       nodeSelector:
+        kubernetes.io/arch: amd64
         phase: prod
       tolerations:
         - effect: NoSchedule

--- a/apps/siksha-prod/siksha-crawler/siksha-crawler.yaml
+++ b/apps/siksha-prod/siksha-crawler/siksha-crawler.yaml
@@ -18,6 +18,7 @@ spec:
             sidecar.istio.io/inject: "false"
         spec:
           nodeSelector:
+            kubernetes.io/arch: amd64
             phase: batch
           tolerations:
             - effect: NoSchedule

--- a/apps/snutt-dev/snutt-ev-batch/snutt-ev-batch.yaml
+++ b/apps/snutt-dev/snutt-ev-batch/snutt-ev-batch.yaml
@@ -18,6 +18,7 @@ spec:
             sidecar.istio.io/inject: "false"
         spec:
           nodeSelector:
+            kubernetes.io/arch: amd64
             phase: batch
           tolerations:
             - effect: NoSchedule
@@ -68,6 +69,7 @@ spec:
             sidecar.istio.io/inject: "false"
         spec:
           nodeSelector:
+            kubernetes.io/arch: amd64
             phase: batch
           tolerations:
             - effect: NoSchedule
@@ -119,6 +121,7 @@ spec:
             sidecar.istio.io/inject: "false"
         spec:
           nodeSelector:
+            kubernetes.io/arch: amd64
             phase: batch
           tolerations:
             - effect: NoSchedule

--- a/apps/snutt-dev/snutt-ev-web/snutt-ev-web.yaml
+++ b/apps/snutt-dev/snutt-ev-web/snutt-ev-web.yaml
@@ -22,6 +22,7 @@ spec:
         app: snutt-ev-web
     spec:
       nodeSelector:
+        kubernetes.io/arch: amd64
         phase: dev
       tolerations:
         - effect: NoSchedule

--- a/apps/snutt-dev/snutt-ev/snutt-ev.yaml
+++ b/apps/snutt-dev/snutt-ev/snutt-ev.yaml
@@ -23,6 +23,7 @@ spec:
     spec:
       serviceAccountName: snutt-ev
       nodeSelector:
+        kubernetes.io/arch: amd64
         phase: dev
       tolerations:
         - effect: NoSchedule

--- a/apps/snutt-dev/snutt-theme-market/snutt-theme-market.yaml
+++ b/apps/snutt-dev/snutt-theme-market/snutt-theme-market.yaml
@@ -22,6 +22,7 @@ spec:
         app: snutt-theme-market
     spec:
       nodeSelector:
+        kubernetes.io/arch: amd64
         phase: dev
       tolerations:
         - effect: NoSchedule

--- a/apps/snutt-dev/snutt-timetable-batch/snutt-timetable-batch.yaml
+++ b/apps/snutt-dev/snutt-timetable-batch/snutt-timetable-batch.yaml
@@ -18,6 +18,7 @@ spec:
             sidecar.istio.io/inject: "false"
         spec:
           nodeSelector:
+            kubernetes.io/arch: amd64
             phase: batch
           tolerations:
             - effect: NoSchedule
@@ -66,6 +67,7 @@ spec:
             sidecar.istio.io/inject: "false"
         spec:
           nodeSelector:
+            kubernetes.io/arch: amd64
             phase: batch
           tolerations:
             - effect: NoSchedule

--- a/apps/snutt-dev/snutt-timetable/snutt-timetable.yaml
+++ b/apps/snutt-dev/snutt-timetable/snutt-timetable.yaml
@@ -23,6 +23,7 @@ spec:
     spec:
       serviceAccountName: snutt-timetable
       nodeSelector:
+        kubernetes.io/arch: amd64
         phase: dev
       tolerations:
         - effect: NoSchedule

--- a/apps/snutt-prod/snutt-ev-batch/snutt-ev-batch.yaml
+++ b/apps/snutt-prod/snutt-ev-batch/snutt-ev-batch.yaml
@@ -18,6 +18,7 @@ spec:
             sidecar.istio.io/inject: "false"
         spec:
           nodeSelector:
+            kubernetes.io/arch: amd64
             phase: batch
           tolerations:
             - effect: NoSchedule
@@ -68,6 +69,7 @@ spec:
             sidecar.istio.io/inject: "false"
         spec:
           nodeSelector:
+            kubernetes.io/arch: amd64
             phase: batch
           tolerations:
             - effect: NoSchedule
@@ -118,7 +120,8 @@ spec:
           annotations:
             sidecar.istio.io/inject: "false"
         spec:
-          nodeSelector:
+          nodeSelector: 
+            kubernetes.io/arch: amd64
             phase: batch
           tolerations:
             - effect: NoSchedule

--- a/apps/snutt-prod/snutt-ev-web/snutt-ev-web.yaml
+++ b/apps/snutt-prod/snutt-ev-web/snutt-ev-web.yaml
@@ -22,6 +22,7 @@ spec:
         app: snutt-ev-web
     spec:
       nodeSelector:
+        kubernetes.io/arch: amd64
         phase: prod
       tolerations:
         - effect: NoSchedule

--- a/apps/snutt-prod/snutt-ev/snutt-ev.yaml
+++ b/apps/snutt-prod/snutt-ev/snutt-ev.yaml
@@ -23,6 +23,7 @@ spec:
     spec:
       serviceAccountName: snutt-ev
       nodeSelector:
+        kubernetes.io/arch: amd64
         phase: prod
       tolerations:
         - effect: NoSchedule

--- a/apps/snutt-prod/snutt-theme-market/snutt-theme-market.yaml
+++ b/apps/snutt-prod/snutt-theme-market/snutt-theme-market.yaml
@@ -22,6 +22,7 @@ spec:
         app: snutt-theme-market
     spec:
       nodeSelector:
+        kubernetes.io/arch: amd64
         phase: prod
       tolerations:
         - effect: NoSchedule

--- a/apps/snutt-prod/snutt-timetable-batch/snutt-timetable-batch.yaml
+++ b/apps/snutt-prod/snutt-timetable-batch/snutt-timetable-batch.yaml
@@ -18,6 +18,7 @@ spec:
             sidecar.istio.io/inject: "false"
         spec:
           nodeSelector:
+            kubernetes.io/arch: amd64
             phase: batch
           tolerations:
             - effect: NoSchedule
@@ -66,6 +67,7 @@ spec:
             sidecar.istio.io/inject: "false"
         spec:
           nodeSelector:
+            kubernetes.io/arch: amd64
             phase: batch
           tolerations:
             - effect: NoSchedule
@@ -114,6 +116,7 @@ spec:
             sidecar.istio.io/inject: "false"
         spec:
           nodeSelector:
+            kubernetes.io/arch: amd64
             phase: batch
           tolerations:
             - effect: NoSchedule

--- a/apps/snutt-prod/snutt-timetable/snutt-timetable.yaml
+++ b/apps/snutt-prod/snutt-timetable/snutt-timetable.yaml
@@ -23,6 +23,7 @@ spec:
     spec:
       serviceAccountName: snutt-timetable
       nodeSelector:
+        kubernetes.io/arch: amd64
         phase: prod
       tolerations:
         - effect: NoSchedule

--- a/apps/sso-dev/account-server/account-server.yaml
+++ b/apps/sso-dev/account-server/account-server.yaml
@@ -23,6 +23,7 @@ spec:
     spec:
       serviceAccountName: account-server
       nodeSelector:
+        kubernetes.io/arch: amd64
         phase: dev
       tolerations:
         - effect: NoSchedule

--- a/apps/sso-dev/kong-gateway/kong-gateway.yaml
+++ b/apps/sso-dev/kong-gateway/kong-gateway.yaml
@@ -22,6 +22,7 @@ spec:
         app: kong-gateway
     spec:
       nodeSelector:
+        kubernetes.io/arch: amd64
         phase: dev
       tolerations:
         - effect: NoSchedule

--- a/apps/sso-prod/account-server/account-server.yaml
+++ b/apps/sso-prod/account-server/account-server.yaml
@@ -23,6 +23,7 @@ spec:
     spec:
       serviceAccountName: account-server
       nodeSelector:
+        kubernetes.io/arch: amd64
         phase: prod
       tolerations:
         - effect: NoSchedule

--- a/apps/sso-prod/kong-gateway/kong-gateway.yaml
+++ b/apps/sso-prod/kong-gateway/kong-gateway.yaml
@@ -22,6 +22,7 @@ spec:
         app: kong-gateway
     spec:
       nodeSelector:
+        kubernetes.io/arch: amd64
         phase: prod
       tolerations:
         - effect: NoSchedule

--- a/apps/truffle-prod/truffle-consumer/truffle-consumer.yaml
+++ b/apps/truffle-prod/truffle-consumer/truffle-consumer.yaml
@@ -23,6 +23,7 @@ spec:
     spec:
       serviceAccountName: truffle
       nodeSelector:
+        kubernetes.io/arch: amd64
         phase: prod
       tolerations:
         - effect: NoSchedule

--- a/apps/truffle-prod/truffle-dashboard/truffle-dashboard.yaml
+++ b/apps/truffle-prod/truffle-dashboard/truffle-dashboard.yaml
@@ -23,6 +23,7 @@ spec:
     spec:
       serviceAccountName: truffle
       nodeSelector:
+        kubernetes.io/arch: amd64
         phase: prod
       tolerations:
         - effect: NoSchedule

--- a/apps/wacruit-dev/wacruit-judge/wacruit-judge-server.yaml
+++ b/apps/wacruit-dev/wacruit-judge/wacruit-judge-server.yaml
@@ -23,6 +23,7 @@ spec:
     spec:
       serviceAccountName: wacruit-judge-server
       nodeSelector:
+        kubernetes.io/arch: amd64
         phase: dev
       tolerations:
         - effect: NoSchedule

--- a/apps/wacruit-dev/wacruit-judge/wacruit-judge-worker.yaml
+++ b/apps/wacruit-dev/wacruit-judge/wacruit-judge-worker.yaml
@@ -23,6 +23,7 @@ spec:
     spec:
       serviceAccountName: wacruit-judge-worker
       nodeSelector:
+        kubernetes.io/arch: amd64
         phase: dev
       tolerations:
         - effect: NoSchedule

--- a/apps/wacruit-dev/wacruit-server/wacruit-server.yaml
+++ b/apps/wacruit-dev/wacruit-server/wacruit-server.yaml
@@ -23,6 +23,7 @@ spec:
     spec:
       serviceAccountName: wacruit-server
       nodeSelector:
+        kubernetes.io/arch: amd64
         phase: dev
       tolerations:
         - effect: NoSchedule

--- a/apps/wacruit-prod/wacruit-judge/wacruit-judge-server.yaml
+++ b/apps/wacruit-prod/wacruit-judge/wacruit-judge-server.yaml
@@ -23,6 +23,7 @@ spec:
     spec:
       serviceAccountName: wacruit-judge-server
       nodeSelector:
+        kubernetes.io/arch: amd64
         phase: prod
       tolerations:
         - effect: NoSchedule

--- a/apps/wacruit-prod/wacruit-judge/wacruit-judge-worker.yaml
+++ b/apps/wacruit-prod/wacruit-judge/wacruit-judge-worker.yaml
@@ -23,6 +23,7 @@ spec:
     spec:
       serviceAccountName: wacruit-judge-worker
       nodeSelector:
+        kubernetes.io/arch: amd64
         phase: prod
       tolerations:
         - effect: NoSchedule

--- a/apps/wacruit-prod/wacruit-server/wacruit-server.yaml
+++ b/apps/wacruit-prod/wacruit-server/wacruit-server.yaml
@@ -25,6 +25,7 @@ spec:
     spec:
       serviceAccountName: wacruit-server
       nodeSelector:
+        kubernetes.io/arch: amd64
         phase: prod
       tolerations:
         - effect: NoSchedule

--- a/apps/waffledotcom-dev/waffledotcom-server/waffledotcom-server.yaml
+++ b/apps/waffledotcom-dev/waffledotcom-server/waffledotcom-server.yaml
@@ -23,6 +23,7 @@ spec:
     spec:
       serviceAccountName: waffledotcom-server
       nodeSelector:
+        kubernetes.io/arch: amd64
         phase: dev
       tolerations:
         - effect: NoSchedule

--- a/apps/waffledotcom-prod/waffledotcom-server/waffledotcom-server.yaml
+++ b/apps/waffledotcom-prod/waffledotcom-server/waffledotcom-server.yaml
@@ -23,6 +23,7 @@ spec:
     spec:
       serviceAccountName: waffledotcom-server
       nodeSelector:
+        kubernetes.io/arch: amd64
         phase: prod
       tolerations:
         - effect: NoSchedule

--- a/misc/addons/cert-manager/cert-manager.yaml
+++ b/misc/addons/cert-manager/cert-manager.yaml
@@ -5198,6 +5198,7 @@ spec:
           securityContext:
             allowPrivilegeEscalation: false
       nodeSelector:
+        kubernetes.io/arch: amd64
         kubernetes.io/os: linux
 ---
 # Source: cert-manager/templates/deployment.yaml
@@ -5255,6 +5256,7 @@ spec:
               fieldRef:
                 fieldPath: metadata.namespace
       nodeSelector:
+        kubernetes.io/arch: amd64
         kubernetes.io/os: linux
 ---
 # Source: cert-manager/templates/webhook-deployment.yaml
@@ -5330,6 +5332,7 @@ spec:
               fieldRef:
                 fieldPath: metadata.namespace
       nodeSelector:
+        kubernetes.io/arch: amd64
         kubernetes.io/os: linux
 ---
 # Source: cert-manager/templates/webhook-mutating-webhook.yaml

--- a/misc/kube-system/metrics-server/components.yaml
+++ b/misc/kube-system/metrics-server/components.yaml
@@ -174,6 +174,7 @@ spec:
         - mountPath: /tmp
           name: tmp-dir
       nodeSelector:
+        kubernetes.io/arch: amd64
         kubernetes.io/os: linux
       priorityClassName: system-cluster-critical
       serviceAccountName: metrics-server


### PR DESCRIPTION
각 deployment yaml에 `kubernetes.io/arch: amd64` nodeSelector를 추가하였습니다.
이는 추후 amd64 노드들에서 arm64 노드들로 마이그레이션하는 과정에서 노드가 잘못 배치되는 것을 막기 위함입니다.
(기존 amd64 노드그룹과 새 arm64 노드그룹을 동시에 띄워 놓고, 아키텍처 변경이 완료된 팀부터 각각 nodeSelector 수정 및 ArgoCD 수동 sync를 진행하여 마이그레이션하도록 안내할 계획입니다. 이는 소통 딜레이로 인한 다운타임을 최대한 줄이기 위함입니다.)

인턴하샤 dev 서버의 경우 arm64로의 변경을 완료했다고 들어 이를 반영하였습니다.
snutt-dev의 경우 아직 아키텍처를 변경하는 pr이 머지되지 않은 상태로 알고 있어 amd64로 설정해 두었습니다.