### PR TITLE
CODEOWNERS 수정

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -19,3 +19,7 @@ apps/snugo/snugo-server/ @wafflestudio/snugo
 apps/areyouhere/ @wafflestudio/areyouhere
 apps/hodu-dev/ @wafflestudio/hodu
 apps/hodu-prod/ @wafflestudio/hodu
+apps/internhasha-dev @wafflestudio/internhasha
+apps/internhasha-prod @wafflestudio/internhasha
+apps/memowithtags-dev @wafflestudio/memo-with-tags
+apps/memowithtags-prod @wafflestudio/memo-with-tags


### PR DESCRIPTION
저번에 에러 난다고 지웠던 internhasha, memowithtags 팀에 대한 codeowners 설정을 다시 추가했습니다
repo 자체에 write 권한이 없으셔서 그랬는데 추가했으니 이제 에러 안날거에요