### PR TITLE
wacruit 내리기

### DIFF
--- a/apps/wacruit-dev/wacruit-server/wacruit-server.yaml
+++ b/apps/wacruit-dev/wacruit-server/wacruit-server.yaml
@@ -6,7 +6,7 @@ metadata:
     app: wacruit-server
   namespace: wacruit-dev
 spec:
-  replicas: 1
+  replicas: 0
   selector:
     matchLabels:
       app: wacruit-server

--- a/apps/wacruit-prod/wacruit-server/wacruit-server.yaml
+++ b/apps/wacruit-prod/wacruit-server/wacruit-server.yaml
@@ -8,7 +8,7 @@ metadata:
   annotations:
     notifications.argoproj.io/subscribe.sync-completed.pupuri-bot: "true"
 spec:
-  replicas: 1
+  replicas: 0
   selector:
     matchLabels:
       app: wacruit-server


### PR DESCRIPTION
* Set `replicas` to 0 in `apps/wacruit-dev/wacruit-server/wacruit-server.yaml` to stop the server in the development environment.
* Set `replicas` to 0 in `apps/wacruit-prod/wacruit-server/wacruit-server.yaml` to stop the server in the production environment.