### PR TITLE
delete : siksha-spring-server

### DIFF
--- a/apps/siksha-prod/siksha-spring-server/siksha-spring-server.yaml
+++ b/apps/siksha-prod/siksha-spring-server/siksha-spring-server.yaml
@@ -6,7 +6,7 @@ metadata:
     app: siksha-spring-server
   namespace: siksha-prod
 spec:
-  replicas: 1
+  replicas: 0
   selector:
     matchLabels:
       app: siksha-spring-server


### PR DESCRIPTION
## summary
식샤 마이그레이션 (fastapi -> siksha-spring-server)로 마이그레이션 과정에 있는것으로 파악,
spring으로 완전한 마이그가 된줄 알았으나 ios, android, web(Fe) 에서 미대응으로 waffle-world의 siksha-api-server name의 pod로 트래픽이 들어오는 것을 파악하였음.
siksha-spring-server는 oracle oci로 이전은 완료되었으므로 이는 제거하고 siksha-api-server만 임시로 남김 